### PR TITLE
pin zstd

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -215,3 +215,5 @@ zeromq:
   - 4.2.1  # should be 4.2.*, but ABI is incorrectly tagged
 zlib:
   - 1.2.11
+zstd:
+  - 1.3.3


### PR DESCRIPTION
`zstd` should be pinned. 1.3.2 [removed symbols](https://abi-laboratory.pro/tracker/timeline/zstd/), and its SONAME now always includes the patch release, so it has to be at the patch level.

Wait on https://github.com/conda-forge/zstd-feedstock/pull/7 before merging so that 1.3.3 actually exists in conda-forge, though. :)