### PR TITLE
pin lz4-c

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -137,6 +137,8 @@ libwebp:
   - 0.5
 libxml2:
   - 2.9
+lz4-c:
+  - 1.8.1
 lzo:
   - 2
 metis:


### PR DESCRIPTION
Patch releases are [usually not backwards compatible](https://abi-laboratory.pro/tracker/timeline/lz4/).