### PR TITLE
Pin libprotobuf

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -123,6 +123,8 @@ libpcap:
   - 1.8
 libpng:
   - 1.6.32
+libprotobuf:
+  - 3.5
 librdkafka:
   - 0.9.4
 libssh2:
@@ -172,8 +174,6 @@ poppler:
   - 0.61
 proj4:
   - 4.9.3
-protobuf:
-  - 3.4
 python:
   - 2.7
   - 3.5


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/14

As the library portion got moved to libprotobuf and we are now at 3.5, change the pinning to libprotobuf and bump the version. Drop protobuf as it is now just the Python version and is pinned exactly to libprotobuf anyways.

cc @isuruf @dougalsutherland