### PR TITLE
Pin gsl to 2.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -71,6 +71,8 @@ fontconfig:
   - 2.12
 freetype:
   - 2.8.1              # [not ppc64le]
+gsl:
+  - 2.2
 gstreamer:
   - 1.12
 gst_plugins_base:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/8

The current version is 2.2.1 and both 2.2 and 2.2.1 seem compatible except for the latter adds more symbols. It seems to break API/ABI on minor versions though. Hence the 2.2 pinning instead of just 2.

cc @conda-forge/gsl 
cc @isuruf and @dougalsutherland (for an extra pair of eyes)