### PR TITLE
Fix lz4-c key name

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -139,7 +139,7 @@ libwebp:
   - 0.5
 libxml2:
   - 2.9
-lz4-c:
+lz4_c:
   - 1.8.1
 lzo:
   - 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
Was using a `-`, but should be using an `_`. This corrects that issue.

cc @dougalsutherland