### PR TITLE
Bump snappy to 1.1.7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -194,7 +194,7 @@ r_base:
 scipy:
   - 0.19
 snappy:
-  - 1.1.6
+  - 1.1.7
 sox:
   - 14.4.2
 sqlite:


### PR DESCRIPTION
Basically compatible with 1.1.6, but has Windows support. Would avoid pinning to patch releases, but snappy has broken compatibility in recent history.

ref: https://abi-laboratory.pro/tracker/timeline/snappy/