### PR TITLE
Pin isl to 0.19

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -97,6 +97,8 @@ hdf5:
   - 1.10.1             # [not ppc64le]
 icu:
   - 58                 # [not ppc64le]
+isl:
+  - 0.19
 jpeg:
   - 9
 json_c:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="2018.03.10" %}
+{% set version = "2018.03.10" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.03.10" %}
+{% set version = "2018.03.18" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
The [API/ABI Report]( https://abi-laboratory.pro/tracker/timeline/isl/ ) shows that `isl` frequently breaks backwards compatibility. This pins `isl` down to the exact version.