### PR TITLE
Pin sqlite to 3.22

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -199,7 +199,7 @@ snappy:
 sox:
   - 14.4.2
 sqlite:
-  - 3.20
+  - 3.22
 sundials:
   - 2.7
 tk:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.03.18" %}
+{% set version = "2018.04.03" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Bumps the `sqlite` pinning to 3.22 from 3.20. Also should help resolve issue ( https://github.com/conda-forge/sqlite-feedstock/issues/25 ).