### PR TITLE
hide vc behind selector for win

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -202,10 +202,10 @@ sundials:
   - 2.7
 tk:
   - 8.6                # [not ppc64le]
-vc:
-  - 9
-  - 14
-  - 14
+vc:                    # [win]
+  - 9                  # [win]
+  - 14                 # [win]
+  - 14                 # [win]
 vlfeat:
   - 0.9.20
 xerces_c:


### PR DESCRIPTION
This is more important in the context of selectors finding used variables.  Without this, conda-build will consider ``vc`` used in unix recipes, because the regex is dumb regarding the "AND" condition that exists in the selectors.