### PR TITLE
bump version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.04.03" %}
+{% set version = "2018.04.16" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
@conda-forge/core are we moving away from the date based release?
If so what should we version this? `1.0.0` and remove the previous releases?