### PR TITLE
update netcdf pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -120,7 +120,7 @@ libkml:
 libmatio:
   - 1.5
 libnetcdf:
-  - 4.4
+  - 4.5
 libpcap:
   - 1.8
 libpng:


### PR DESCRIPTION
I was informed by the netcdf-c team that there was a soname change but ABI compatibility should be OK up to `v4.6.1`.