### PR TITLE
remove pin_run_as_build

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -38,12 +38,6 @@ zip_keys:
     - c_compiler                # [win]
     - cxx_compiler              # [win]
 
-# pin_run_as_build for packages from defaults
-pin_run_as_build:
-  numpy:
-    max_pin: x
-    min_pin: x.x
-
 # Pinning packages
 arpack:
   - 3.5


### PR DESCRIPTION
It is not good to do numpy here. Better to do it on the recipe level, not the variant level, as documented at https://conda.io/docs/user-guide/tasks/build-packages/variants.html#pinning-at-the-recipe-level

The reason is that when numpy is purely used for its python interface, not its C interface, we don't want to pin it in run depends at all. If we define the pin_run_as_build value, rather than using pin_compatible, it will always have a run constraint, even when we don't want it (i.e. with numpy's python interface only)