### PR TITLE
bump + loosen curl pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -51,7 +51,7 @@ pin_run_as_build:
   cairo:
     max_pin: x.x
   curl:
-    max_pin: x.x
+    max_pin: x
   dbus:
     max_pin: x
   expat:
@@ -214,7 +214,7 @@ bzip2:
 cairo:
   - 1.14
 curl:
-  - 7.44
+  - 7.48
 dbus:
   - 1
 expat:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -214,7 +214,7 @@ bzip2:
 cairo:
   - 1.14
 curl:
-  - 7.48
+  - 7.59
 dbus:
   - 1
 expat:


### PR DESCRIPTION
I don't know what the full solution to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/47 / https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/52#discussion_r184868459 is. But this updates `curl` to the oldest version that we actually have a build of, while also loosening the pin since it seems always forward compatible.

This will allow e.g. https://github.com/conda-forge/pdal-feedstock/pull/24 and thereby https://github.com/conda-forge/staged-recipes/pull/5724#discussion_r185812164 to go through.

cc @isuruf, @jakirkham