### PR TITLE
pin_run_as_build for boost, boost-cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -46,6 +46,10 @@ zip_keys:
 pin_run_as_build:
   arpack:
     max_pin: x.x
+  boost:
+    max_pin: x.x.x
+  boost_cpp:
+    max_pin: x.x.x
   bzip2:
     max_pin: x.x
   cairo:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -48,7 +48,7 @@ pin_run_as_build:
     max_pin: x.x
   boost:
     max_pin: x.x.x
-  boost_cpp:
+  boost-cpp:
     max_pin: x.x.x
   bzip2:
     max_pin: x.x
@@ -72,7 +72,7 @@ pin_run_as_build:
     max_pin: x.x
   gstreamer:
     max_pin: x.x
-  gst_plugins_base:
+  gst-plugins-base:
     max_pin: x.x
   gdal:
     max_pin: x.x
@@ -98,7 +98,7 @@ pin_run_as_build:
     max_pin: x.x
   jpeg:
     max_pin: x
-  json_c:
+  json-c:
     max_pin: x.x
   krb5:
     max_pin: x.x
@@ -138,7 +138,7 @@ pin_run_as_build:
     max_pin: x.x
   libxml2:
     max_pin: x.x
-  lz4_c:
+  lz4-c:
     max_pin: x.x.x
   lzo:
     max_pin: x
@@ -150,9 +150,9 @@ pin_run_as_build:
     max_pin: x
   ncurses:
     max_pin: x.x
-  netcdf_cxx4:
+  netcdf-cxx4:
     max_pin: x.x
-  netcdf_fortran:
+  netcdf-fortran:
     max_pin: x.x
   nettle:
     max_pin: x.x
@@ -178,7 +178,7 @@ pin_run_as_build:
     max_pin: x.x
   readline:
     max_pin: x.x
-  r_base:
+  r-base:
     max_pin: x.x.x
   snappy:
     max_pin: x.x.x
@@ -194,7 +194,7 @@ pin_run_as_build:
     max_pin: x
   vlfeat:
     max_pin: x.x.x
-  xerces_c:
+  xerces-c:
     max_pin: x.x.x
   xz:
     max_pin: x.x


### PR DESCRIPTION
Boost breaks the ABI [with minor versions](https://abi-laboratory.pro/tracker/timeline/boost/).

I think this is the right behavior: we don't want `run_exports` because you don't want to require it at `run` if it's used header-only, but this allows people to list just `- boost` in the `run` reqs rather than having to do `{{ pin_compatible('boost', max_pin='x.x.x') }}` (and look up how many `x`s you need).