### PR TITLE
Pin jsoncpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -100,6 +100,8 @@ pin_run_as_build:
     max_pin: x
   json-c:
     max_pin: x.x
+  jsoncpp:
+    max_pin: x.x.x
   krb5:
     max_pin: x.x
   libblitz:
@@ -265,6 +267,8 @@ jpeg:
   - 9
 json_c:
   - 0.12
+jsoncpp:
+  - 1.8.1
 krb5:
   - 1.14
 libblitz:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/34

As `jsoncpp` breaks frequently at the patch version, go ahead and pin `jsoncpp` down to the patch version. Use the current version of `jsoncpp` to start off the pinning.

ref: https://abi-laboratory.pro/tracker/timeline/jsoncpp/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
