### PR TITLE
Pin glew to the minor version number

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -80,6 +80,8 @@ pin_run_as_build:
     max_pin: x.x.x
   giflib:
     max_pin: x.x
+  glew:
+    max_pin: x.x
   glib:
     max_pin: x.x
   glpk:
@@ -247,6 +249,8 @@ geos:
   - 3.6.2
 giflib:
   - 5.1
+glew:
+  - 2.0.0
 glib:
   - 2.55
 glpk:


### PR DESCRIPTION
As GLEW changes its SONAME every minor version, we need to pin down to the minor version. Seems patch releases don't generate much breakage (when they do occur). So just pinning to the minor version number is sufficient. Also start with the current version of GLEW in conda-forge.

ref: https://abi-laboratory.pro/tracker/timeline/glew/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
