### PR TITLE
Loose ncurses pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -155,7 +155,7 @@ pin_run_as_build:
   mpfr:
     max_pin: x
   ncurses:
-    max_pin: x.x
+    max_pin: x
   netcdf-cxx4:
     max_pin: x.x
   netcdf-fortran:


### PR DESCRIPTION
Although 2 symbols were removed in the last minor release, they were obsoleted since 2004.
https://www.gnu.org/software/ncurses/