### PR TITLE
1.12 is not available for osx.

### DIFF
--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -29,7 +29,7 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-test -d "$ARTIFACTS" || mkdir "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -242,9 +242,11 @@ gf2x:
 gsl:
   - 2.2
 gstreamer:
-  - 1.12
+  - 1.12  # [linux]
+  - 1.14.0  # [osx]
 gst_plugins_base:
-  - 1.12
+  - 1.12  # [linux]
+  - 1.14.0  # [osx]
 gdal:
   - 2.2
 geos:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This changes the pinning to use 1.14 on osx because 1.12 is not available foe osx. See https://github.com/conda-forge/staged-recipes/pull/5966#issuecomment-393048712
