### PR TITLE
zeromq 4.2.5

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -217,7 +217,7 @@ pin_run_as_build:
   xz:
     max_pin: x.x
   zeromq:
-    max_pin: x.x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
   zstd:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -406,7 +406,7 @@ xerces_c:
 xz:
   - 5.2
 zeromq:
-  - 4.2.1  # should be 4.2.*, but ABI is incorrectly tagged
+  - 4.2.5
 zlib:
   - 1.2
 zstd:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.06.29" %}
+{% set version = "2018.07.01" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Since ABI fixes in the recipe, this *should* work with `>=4.2.5,<4.3`. <del>But I'm not sure if we want to do that right now.</del> Updated zeromq max_pin to x.x, so it should get the right pinning on build.
