### PR TITLE
Pin graphviz

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -98,6 +98,8 @@ pin_run_as_build:
     max_pin: x.x
   gmp:
     max_pin: x
+  graphviz:
+    max_pin: x
   harfbuzz:
     max_pin: x.x
   hdf4:
@@ -273,6 +275,8 @@ glpk:
   - 4.65
 gmp:
   - 6
+graphviz:
+  - 2.38.0
 harfbuzz:
   - 1.7
 hdf4:


### PR DESCRIPTION
Sets the minimum version of `graphviz` to 2.38.0. This is the latest version in conda-forge. Despite a couple breaks 5 years ago, `graphviz` has been remarkably stable since only adding new symbols. So keep the maximum pinning lax.

ref: https://abi-laboratory.pro/?view=timeline&l=graphviz

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
