### PR TITLE
Loosen harfbuzz pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -101,7 +101,7 @@ pin_run_as_build:
   graphviz:
     max_pin: x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf4:
     max_pin: x.x
   hdf5:
@@ -282,7 +282,7 @@ gmp:
 graphviz:
   - 2.38.0
 harfbuzz:
-  - 1.7
+  - 1
 hdf4:
   - 4.2
 hdf5:


### PR DESCRIPTION
As per [its ABI report](https://abi-laboratory.pro/?view=timeline&l=harfbuzz), things have been quite stable for a while, and current packages are stuck on the 1.7 series while we've been packaging the 1.8 series for a little while now.

PS: I haven't futzed with the pinning file before, so this change could use a more-in-depth-than-usual review, although I'm *pretty* sure it's trivial ...