### PR TITLE
specify mpi provider matrix

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -36,6 +36,9 @@ macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
+mpi:                           # [unix]
+  - mpich                      # [unix]
+  - openmpi                    # [unix]
 target_platform:
   - win-64                     # [win]
 VERBOSE_AT:


### PR DESCRIPTION
so recipes can have just `{{ mpi }}` and get both openmpi and mpich without needing their own conda_build_config.yaml. It seems like this is a reasonable thing, since most packages seem to be adding mpi variants? If not, feel free to close and packages can add their mpi variants in their own conda_build_config.yaml as they are doing now.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->