### PR TITLE
Add go_compiler to conda-forge pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -30,6 +30,8 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
+go_compiler:
+  - go
 macos_min_version:             # [osx]
   - 10.9                       # [osx]
 macos_machine:                 # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.07.01" %}
+{% set version = "2018.07.15" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Now that conda-forge/go-feedstock#21 has been merged it is time to add
the go_compiler entry to conda_build_config.

cc: @scopatz, @nehaljwani


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->