### PR TITLE
re-pin libnetcdf

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -376,7 +376,7 @@ libkml:
 libmatio:
   - 1.5
 libnetcdf:
-  - 4.6
+  - 4.4
 libpcap:
   - 1.8
 libpng:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.08.28" %}
+{% set version = "2018.08.30" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
See https://github.com/Unidata/netcdf4-python/issues/836

I'll merge this tomorrow, pull all the `libnetcdf >4.4.x`, and start re-building stuff :unamused: 

Ping @dopplershift 