### PR TITLE
revert proj4 pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -445,7 +445,7 @@ pixman:
 poppler:
   - 0.67
 proj4:
-  - 5.1.0
+  - 4.9.3
 python:
   - 2.7
   - 3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.08.28" %}
+{% set version = "2018.08.31" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
@pelson I was following the lead on `defaults` but now I realized that `cartopy` and `pyproj` are not actually ready for this. I'm reverting this pin, pulling the binaries, and re-building stuff... Hurray I know what I will be doing all my weekend :grimacing: 