### PR TITLE
Bump glib pin to 2.56, matching defaults

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -329,7 +329,7 @@ giflib:
 glew:
   - 2.0.0
 glib:
-  - 2.55
+  - 2.56
 glpk:
   - 4.65
 gmp:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.08.31" %}
+{% set version = "2018.09.11" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
As per #21.