### PR TITLE
Pin nlopt

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -227,6 +227,8 @@ pin_run_as_build:
     max_pin: x.x
   nettle:
     max_pin: x.x
+  nlopt:
+    max_pin: x.x.x
   occt:
     max_pin: x.x
   openblas:
@@ -417,6 +419,8 @@ netcdf_fortran:
   - 4.4
 nettle:
   - 3.3
+nlopt:
+  - 2.5.*
 ntl:
   - 10.3.0
 # we build for an old version of numpy for forward compatibility

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.10.03" %}
+{% set version = "2018.10.08" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
hello,
nlopt's commit
https://github.com/stevengj/nlopt/commit/61fe5161861c7658c70563fbf3abf456fb3ce980
adds get_errmsg (after 2.4.2), and it's used in the public cxx interface, so libs linked against nlopt 2.5.0 cannot be used with 2.4, I experienced it with openturns packages today (https://github.com/conda-forge/openturns-feedstock/pull/61)
As there are other c++ packages here (https://github.com/search?l=YAML&q=org%3Aconda-forge+nlopt&type=Code) that depend on nlopt I propose to move the pin here.