### PR TITLE
Pin librdkafka to 0.11.5

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -384,7 +384,7 @@ libpng:
 libprotobuf:
   - 3.5
 librdkafka:
-  - 0.9.4
+  - 0.11.5
 libsecret:
   - 0.18
 libssh2:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.10.08" %}
+{% set version = "2018.10.10" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
[Apologies if this is premature or if this is the wrong venue for this proposal.]

I was wondering if it would be possible to upgrade the pinning of `librdkafka`.  The current pinning is fairly old (`0.9.4`, from 1.5 years ago).

From a quick scan of the [0.11 release notes](https://github.com/edenhill/librdkafka/releases/tag/v0.11.0), it looks like there are a few minor API changes, but I don't know how much they will affect other conda-forge packages.

cc: @conda-forge/librdkafka 