### PR TITLE
pin libpq

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -191,6 +191,8 @@ pin_run_as_build:
     max_pin: x.x
   libpng:
     max_pin: x.x
+  libpq:
+    max_pin: x.x
   libprotobuf:
     max_pin: x.x
   librdkafka:
@@ -381,6 +383,8 @@ libpcap:
   - 1.8
 libpng:
   - 1.6.34
+libpq:
+  - 10.5
 libprotobuf:
   - 3.5
 librdkafka:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Would it be worth to pin libpq here, so downstream dependencies like psychopg2 get consistent on the stack?

Attending to the postgres ABI lab (https://abi-laboratory.pro/index.php?view=timeline&l=postgresql)
I think x.x is the right pin.