### PR TITLE
Use new conda-forge docker image for compilers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -71,7 +71,7 @@ channel_targets:
 
 docker_image:                                   # [linux or ppc64le]
   - condaforge/linux-anvil                      # [linux]
-  - conda/c3i-linux-64                          # [linux              and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - condaforge/linux-anvil-comp7                # [linux              and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
   - condaforge/ppc-anvil                        # [ppc64le]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.10.11" %}
+{% set version = "2018.10.13" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Switches to the `condaforge/linux-anvil-comp7` image for building packages. This is basically the same as `condaforge/linux-anvil` except that it does not install the `devtoolset-2` compilers. Meaning it builds under a non-`root` (regular) user. Also it has access to `yum` for installing things so can satisfy `yum_requirements.txt`. As both of these weren't possible on the Anaconda image, several feedstocks were blocked from migration. This should help unblock them.

----

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

----

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-smithy/issues/890

<!--
Please add any other relevant info below:
-->

cc @conda-forge/core