### PR TITLE
update libwebp pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -396,7 +396,7 @@ libtiff:
 libunwind:
   - 1.2
 libwebp:
-  - 0.5
+  - 1.0.0
 libxml2:
   - 2.9
 libuuid:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.10.13" %}
+{% set version = "2018.10.16" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
The bot built `libwebp 1.0.0` so instead of keeping an old version in a branch let's bump the pin.