### PR TITLE
Bump `libpng` to 1.6.35

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -380,7 +380,7 @@ libnetcdf:
 libpcap:
   - 1.8
 libpng:
-  - 1.6.34
+  - 1.6.35
 libprotobuf:
   - 3.5
 librdkafka:


### PR DESCRIPTION
As we rebuilt `libpng` 1.6.35 with the new compilers, but not `libpng` 1.6.34, this bumps our minimum `libpng` version to 1.6.35.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
