### PR TITLE
Bump gdal

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -321,7 +321,7 @@ gst_plugins_base:
   - 1.12  # [linux]
   - 1.14.0  # [osx]
 gdal:
-  - 2.2
+  - 2.3
 geos:
   - 3.6.2
 giflib:
@@ -368,7 +368,7 @@ libevent:
 libffi:
   - 3.2
 libgdal:
-  - 2.2
+  - 2.3
 libiconv:
   - 1.15
 libkml:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.10.16" %}
+{% set version = "2018.10.31" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Now that `fiona 1.8` was released we can pin the stack to `gdal 2.3`.

Pinging @msarahan and @jjhelmus who may want to do the same in `defaults`.