### PR TITLE
remove mpi pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -50,9 +50,6 @@ macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
-mpi:                           # [unix]
-  - mpich                      # [unix]
-  - openmpi                    # [unix]
 target_platform:
   - win-64                     # [win]
 VERBOSE_AT:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.9" %}
+{% set version = "2018.11.13" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
having this here prevents other recipes from adding a nompi variant

I think this is a conda-build bug, because I would assume that `conda_build_config.yaml` in the recipe would override this here, but it doesn't. Only if this is removed will the following conda_build_config.yaml in the recipe work as expected:

```yaml
mpi:
- mpich
- openmpi
- nompi
```

Alternately, it could be a bug in conda-smithy's explosion of variants.

Lacking this in the pinning ought to be no harm to existing recipes, which all already have the mpi variants in their recipe conda_build_config.yaml.

cc @ax3l who I believe just ran into this.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->