### PR TITLE
Only pin to R 3.5.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -457,7 +457,6 @@ qt:
 readline:
   - 7.0
 r_base:
-  - 3.4.1
   - 3.5.1
 snappy:
   - 1.1.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.18" %}
+{% set version = "2018.11.13" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.9" %}
+{% set version = "2018.11.18" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

R 3.4.1 was never rebuilt with the newer compilers and its debatable whether that's even worth while (a lot of effort seems to have gone into getting R 3.5.1 rebuilt and 3.4.1 is obsolete anyway). This closes #147 and should therefore facilitate most of the current R package feedstocks getting rebuilt with newer compilers.