### PR TITLE
bump jsoncpp to 1.8.4

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -347,7 +347,7 @@ json_c:
   - 0.12  # [not win]
   - 0.13  # [win]
 jsoncpp:
-  - 1.8.1
+  - 1.8.4
 kealib:
   - 1.4.10
 krb5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.21" %}
+{% set version = "2018.11.26" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
PR as requested by @jakirkham  in conda-forge/vtk-feedstock#72

This is the only version of jsoncpp that appears to have been built during the compiler rebuild.

I wasn't sure of the convention in this feedstock, but I bumped the build number since the version already matched today's date.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
