### PR TITLE
Re pin gsl

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -306,7 +306,7 @@ freetype:
 gf2x:
   - 1.2
 gsl:
-  - 2.2
+  - 2.4
 gstreamer:
   - 1.12  # [linux]
   - 1.14.0  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.24" %}
+{% set version = "2018.11.25" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Only 2.4 is available for the new compilers.