### PR TITLE
Update curl pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -292,7 +292,7 @@ bzip2:
 cairo:
   - 1.14
 curl:
-  - 7.59
+  - 7
 dbus:
   - 1
 expat:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -183,6 +183,8 @@ pin_run_as_build:
     max_pin: x.x
   libblitz:
     max_pin: x.x
+  libcurl:
+    max_pin: x
   libdap4:
     max_pin: x.x
   libevent:
@@ -314,7 +316,7 @@ bzip2:
 cairo:
   - 1.16
 curl:
-  - 7
+  - 7.64
 dbus:
   - 1
 expat:
@@ -382,6 +384,8 @@ krb5:
   - 1.16
 libblitz:
   - 0.10
+libcurl:
+  - 7.64
 libdap4:
   - 3.19
 libevent:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.27" %}
+{% set version = "2018.11.29" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Note that 7.59 is not rebuilt for gcc7 label, so this was pulling in curl from defaults. I was thinking of bumping to 7.62, but since the pin was just `x`, we can keep it at 7.