### PR TITLE
Advance `glib` pin to 2.58 and bump version to 2018.12.28.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -328,7 +328,7 @@ giflib:
 glew:
   - 2.0.0
 glib:
-  - 2.56
+  - 2.58
 glpk:
   - 4.65
 gmp:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.12.18" %}
+{% set version = "2018.12.28" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Does what it says on the tin.