### PR TITLE
Specify that dual compiler is only for linux64, not linux-aarch64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,7 +9,7 @@ blas_impl:
 cross_compiler_target_platform:  # [win]
   - win-64                     # [win]
 c_compiler:
-  - toolchain_c                # [linux or osx]
+  - toolchain_c                # [linux64 or osx]
   # new compilers
   - gcc                        # [linux                               and (environ.get('CF_COMPILER_STACK') == 'comp7')]
   - clang                      # [osx                                 and (environ.get('CF_COMPILER_STACK') == 'comp7')]
@@ -20,7 +20,7 @@ c_compiler:
   - vs2015                     # [win]
   - vs2015                     # [win and (environ.get('CF_MAX_PY_VER', '') >= '37')]
 cxx_compiler:
-  - toolchain_cxx              # [linux or osx]
+  - toolchain_cxx              # [linux64 or osx]
   # new compilers
   - gxx                        # [linux                               and (environ.get('CF_COMPILER_STACK') == 'comp7')]
   - clangxx                    # [osx                                 and (environ.get('CF_COMPILER_STACK') == 'comp7')]
@@ -31,7 +31,7 @@ cxx_compiler:
   - vs2015                     # [win]
   - vs2015                     # [win and (environ.get('CF_MAX_PY_VER', '') >= '37')]
 fortran_compiler:              # [unix or win64]
-  - toolchain_fort             # [unix and not ppc64le]
+  - toolchain_fort             # [(linux64 or osx) and not ppc64le]
   - gfortran                   # [(linux or osx)                      and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
   - gfortran                   # [ppc64le]
@@ -60,21 +60,24 @@ VERBOSE_CM:
 # dual build configuration
 channel_sources:
   - conda-forge,defaults
-  - conda-forge/label/gcc7,defaults             # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - conda-forge/label/gcc7,defaults             # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - jjhelmus/label/aarch64_bootstrap,defaults   # [aarch64]
+  - archiarm,defaults                           # [aarch64]
 
 channel_targets:
   - conda-forge main
   - conda-forge gcc7                            # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - archiarm main                               # [aarch64]
 
-docker_image:                                   # [linux or ppc64le]
-  - condaforge/linux-anvil                      # [linux]
-  - condaforge/linux-anvil-comp7                # [linux              and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+docker_image:                                   # [linux64 or ppc64le]
+  - condaforge/linux-anvil                      # [linux64]
+  - condaforge/linux-anvil-comp7                # [linux64              and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
   - condaforge/ppc-anvil                        # [ppc64le]
 
-build_number_decrement:                         # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-  - 1000                                        # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-  - 0                                           # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+build_number_decrement:                         # [(linux   or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - 1000                                        # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - 0                                           # [(linux   or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
 zip_keys:
   -
@@ -93,7 +96,7 @@ zip_keys:
     - fortran_compiler          # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - channel_sources           # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - channel_targets           # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - docker_image              # [linux                              and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - docker_image              # [linux64                            and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - build_number_decrement    # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
 # TODO: remove these when run_exports are added to the packages.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -83,8 +83,8 @@ zip_keys:
   -
     - python
     - vc                        # [win]
-    - c_compiler                # [not (linux64 or osx)]
-    - cxx_compiler              # [not (linux64 or osx)]
+    - c_compiler                # [win]
+    - cxx_compiler              # [win]
 
   # Dual compiler zip
   -                             # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -61,13 +61,10 @@ VERBOSE_CM:
 channel_sources:
   - conda-forge,defaults
   - conda-forge/label/gcc7,defaults             # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-  - jjhelmus/label/aarch64_bootstrap,defaults   # [aarch64]
-  - archiarm,defaults                           # [aarch64]
 
 channel_targets:
   - conda-forge main                            # [not aarch64]
   - conda-forge gcc7                            # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-  - archiarm main                               # [aarch64]
 
 docker_image:                                   # [linux64 or ppc64le]
   - condaforge/linux-anvil                      # [linux64]
@@ -75,9 +72,9 @@ docker_image:                                   # [linux64 or ppc64le]
 
   - condaforge/ppc-anvil                        # [ppc64le]
 
-build_number_decrement:                         # [(linux   or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+build_number_decrement:                         # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
   - 1000                                        # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-  - 0                                           # [(linux   or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - 0                                           # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
 zip_keys:
   -

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -65,8 +65,8 @@ channel_sources:
   - archiarm,defaults                           # [aarch64]
 
 channel_targets:
-  - conda-forge main
-  - conda-forge gcc7                            # [(linux or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  - conda-forge main                            # [not aarch64]
+  - conda-forge gcc7                            # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
   - archiarm main                               # [aarch64]
 
 docker_image:                                   # [linux64 or ppc64le]
@@ -94,7 +94,7 @@ zip_keys:
     - c_compiler                # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - cxx_compiler              # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - fortran_compiler          # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - channel_sources           # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - channel_sources           # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - channel_targets           # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - docker_image              # [linux64                            and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - build_number_decrement    # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -86,18 +86,18 @@ zip_keys:
   -
     - python
     - vc                        # [win]
-    - c_compiler                # [win]
-    - cxx_compiler              # [win]
+    - c_compiler                # [not (linux64 or osx)]
+    - cxx_compiler              # [not (linux64 or osx)]
 
   # Dual compiler zip
-  -                             # [                                       (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - c_compiler                # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - cxx_compiler              # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - fortran_compiler          # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+  -                             # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - c_compiler                # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - cxx_compiler              # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - fortran_compiler          # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
     - channel_sources           # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - channel_targets           # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - docker_image              # [linux64                            and (environ.get('CF_COMPILER_STACK') == 'comp7')]
-    - build_number_decrement    # [(linux or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - channel_targets           # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - docker_image              # [ linux64                           and (environ.get('CF_COMPILER_STACK') == 'comp7')]
+    - build_number_decrement    # [(linux64 or osx)                   and (environ.get('CF_COMPILER_STACK') == 'comp7')]
 
 # TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 50
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 50
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
I would like to make this compatible with aarch64.

A few things don't make sense for aarch64, specifically, the dual compiler stream.

I haven't added any `[aarch64]` in this pr, but rather made `linux` pretty specific to `linux64`, which is all that conda-forge compiles for today.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
