### PR TITLE
[RFC] Update the go and cgo compilers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -42,10 +42,25 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
 go_compiler:
   - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
 cgo_compiler:
   - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
 target_goos:
   - linux                      # [linux]
   - darwin                     # [osx]
@@ -53,6 +68,13 @@ target_goos:
 target_goarch:
   - 386                        # [x86]
   - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
 macos_min_version:             # [osx]
   - 10.9                       # [osx]
 macos_machine:                 # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -74,7 +74,6 @@ target_goos:
   - darwin                     # [osx]
   - windows                    # [win]
 target_goarch:
-  - 386                        # [x86]
   - amd64                      # [x86_64]
 target_goexe:
   -                            # [unix]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -43,7 +43,9 @@ m2w64_cxx_compiler:            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
 go_compiler:
-  - go
+  - go-nocgo
+cgo_compiler:
+  - go-cgo
 macos_min_version:             # [osx]
   - 10.9                       # [osx]
 macos_machine:                 # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -46,6 +46,13 @@ go_compiler:
   - go-nocgo
 cgo_compiler:
   - go-cgo
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - 386                        # [x86]
+  - amd64                      # [x86_64]
 macos_min_version:             # [osx]
   - 10.9                       # [osx]
 macos_machine:                 # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.12.28" %}
+{% set version = "2018.12.30" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
- Changed the go compiler to point to go-nocgo
- Added the cgo compiler that points to go-cgo

The main difference is that CGO can be used to create GO programs that link
to other C/C++/Fortran libraries, while nocgo can only be used for pure go
code.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->