### PR TITLE
update geos to 3.7.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -324,7 +324,7 @@ gst_plugins_base:
 gdal:
   - 2.3
 geos:
-  - 3.7.0
+  - 3.7.1
 geotiff:
   - 1.4.2
 giflib:


### PR DESCRIPTION
Pinning [geos](https://anaconda.org/conda-forge/geos/files) to 3.7.1, because this version was rebuild against GCC7.

