### PR TITLE
Update harfbuzz pin to 2.x series and bump version to 2019.01.16.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -347,7 +347,7 @@ gmp:
 graphviz:
   - 2.38.0
 harfbuzz:
-  - 1
+  - 2
 hdf4:
   - 4.2
 hdf5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.01.15" %}
+{% set version = "2019.01.16" %}
 
 package:
   name: conda-forge-pinning
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
ABI Laboratory shows that the 2.x series has been backward-compatible since the 2.0 release. We need to start using the newer harfbuzz to start using the newer cairo (namely the 1.16 series) in places like gtk-2 and librsvg.

CC @croth1 and conda-forge/gtk2-feedstock#8: I ran into another issue where this old pin was holding things back, so I went ahead and put together the PR.