### PR TITLE
Add cdt_name, build for aarch64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,7 +17,7 @@ c_compiler:
   # non-standard arches get built with gcc
   - gcc                        # [aarch64]
   - gcc                        # [ppc64le]
-  
+
   - vs2008                     # [win]
   - vs2015                     # [win]
   - vs2015                     # [win]
@@ -103,6 +103,13 @@ zip_keys:
     - channel_targets           # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
     - docker_image              # [linux64                              and (environ.get('CF_COMPILER_STACK') == 'comp4')]
     - build_number_decrement    # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+cdt_name: cos7                          # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
 
 # TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.01.18" %}
+{% set version = "2019.01.20" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
To build on aarch64, we (jjhelmus and I) had to add a few things to the yaml

```
cdt_arch: aarch64
cdt_name: cos7
BUILD: aarch64-conda_cos7-linux-gnu
```

not sure if target_platform is necessary, but the others are because the compilers don't target cos6 so you have to change what conda-build thinks is correct.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

cc: @mariusvniekerk 
