### PR TITLE
aarch64 pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -360,7 +360,8 @@ hdf4:
 hdf5:
   - 1.10.4
 icu:
-  - 58
+  - 58   # [not aarch64]
+  - 60   # [aarch64]
 isl:
   - 0.19
 jasper:
@@ -398,7 +399,8 @@ libnetcdf:
 libpcap:
   - 1.8
 libpng:
-  - 1.6.35
+  - 1.6.35   # [not aarch64]
+  - 1.6.36   # [aarch64]
 libprotobuf:
   - 3.6
 librdkafka:
@@ -410,7 +412,8 @@ libssh2:
 libsvm:
   - 3.21
 libtiff:
-  - 4.0.9
+  - 4.0.9    # [not aarch64]
+  - 4.0.10   # [aarch64]
 libunwind:
   - 1.2
 libwebp:
@@ -420,7 +423,8 @@ libxml2:
 libuuid:
   - 2.32.1
 lz4_c:
-  - 1.8.1
+  - 1.8.1    # [not aarch64]
+  - 1.8.3    # [aarch64]
 lzo:
   - 2
 metis:
@@ -448,12 +452,14 @@ ntl:
 # we build for an old version of numpy for forward compatibility
 #    1.11 seems to be the oldest on win that works with scipy 0.19.  Compiler errors otherwise.
 numpy:
-  - 1.9   # [unix]
+  - 1.9    # [unix]
+  - 1.11   # [aarch64]
   - 1.11   # [win]
 occt:
   - 7.3
 openblas:
-  - 0.3.3
+  - 0.3.3      # [not aarch64]
+  - 0.3.5      # [aarch64]
 openjpeg:
   - 2.3
 openssl:
@@ -509,4 +515,5 @@ zeromq:
 zlib:
   - 1.2
 zstd:
-  - 1.3.3
+  - 1.3.3  # [not aarch64]
+  - 1.3.7  # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
When going through the aarch64 migration, it isn't really fun to go back in time and build older packages just for the pinnings.

For aarch64, it is almost necessary to build bleeding edge packages at time because of some bugs in the build tools or software itself that make it impossible to compile older versions.

This helps aarch64 pinnigns move forward, without affecting other pinnings.

These pinnings got me to the point where I could (almost) compile matplotlib.

cc @mariusvniekerk 
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
