### PR TITLE
Advances gstreamer pin to 1.14.x

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -141,8 +141,6 @@ pin_run_as_build:
     max_pin: x
   gsl:
     max_pin: x.x
-  gst-plugins-base:
-    max_pin: x.x
   gdal:
     max_pin: x.x
   geos:
@@ -330,8 +328,7 @@ gsl:
 gstreamer:
   - 1.14.4
 gst_plugins_base:
-  - 1.12  # [linux]
-  - 1.14.0  # [osx]
+  - 1.14.4
 gdal:
   - 2.4
 geos:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -141,8 +141,6 @@ pin_run_as_build:
     max_pin: x
   gsl:
     max_pin: x.x
-  gstreamer:
-    max_pin: x.x
   gst-plugins-base:
     max_pin: x.x
   gdal:
@@ -154,8 +152,6 @@ pin_run_as_build:
   giflib:
     max_pin: x.x
   glew:
-    max_pin: x.x
-  glib:
     max_pin: x.x
   glpk:
     max_pin: x.x
@@ -332,8 +328,7 @@ gf2x:
 gsl:
   - 2.4
 gstreamer:
-  - 1.12  # [linux]
-  - 1.14.0  # [osx]
+  - 1.14.4
 gst_plugins_base:
   - 1.12  # [linux]
   - 1.14.0  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.01.21" %}
+{% set version = "2019.01.29" %}
 
 package:
   name: conda-forge-pinning
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

My first attempt to advance pins. Can someone verify that this is done correctly? 
Version 1.14.0 is now pinned, 1.14.x can be used during runtime, due to this code https://github.com/conda-forge/gstreamer-feedstock/blob/master/recipe/meta.yaml#L26

I removed the max_pin, because it seems to be transferred to gstreamer already.
