### PR TITLE
Bump version

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -29,3 +29,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.02.11" %}
+{% set version = "2019.02.15" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Bumps the version number as [the migrator bot created a bad PR](https://github.com/conda-forge/root-feedstock/pull/20/files#diff-fa3b1e8d0e648a7a0806db392f183328L49) due to #187.

@conda-forge-admin, please rerender