### PR TITLE
Add a `win` selector to `target_platform`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -58,7 +58,7 @@ macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
-target_platform:
+target_platform:               # [win]
   - win-64                     # [win]
 VERBOSE_AT:
   - V=1


### PR DESCRIPTION
As this is Windows specific and there may be unintended consequences to leaving the Windows selector off of this `target_platform` portion, go ahead and add the Windows selector to it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
