### PR TITLE
update libnetcdf pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -200,7 +200,7 @@ pin_run_as_build:
   libmatio:
     max_pin: x.x
   libnetcdf:
-    max_pin: x.x
+    max_pin: x.x.x
   libpcap:
     max_pin: x.x
   libpng:
@@ -401,7 +401,7 @@ libkml:
 libmatio:
   - 1.5
 libnetcdf:
-  - 4.6
+  - 4.6.2
 libpcap:
   - 1.8
 libpng:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.02.24" %}
+{% set version = "2019.03.04" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Sadly `libnetcdf 4.6.3` broke our nice streak of `x.x` pinning and changed the `soname` from `libnetcdf.so.13` to `libnetcdf.so.15`. (There is no ABI lab link.)

I'm pinning to the exact version before updating the pinning to `4.6.3`, re-rendering some key packages, and removing the previous build number of those packages.