### PR TITLE
pin libspatialindex

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -246,6 +246,8 @@ pin_run_as_build:
     max_pin: x.x.x
   librsvg:
     max_pin: x.x
+  libspatialindex:
+    max_pin: x.x
   libssh2:
     max_pin: x.x
   libsvm:
@@ -465,6 +467,8 @@ librsvg:
   - 2.44.3
 libsecret:
   - 0.18
+libspatialindex:
+  - 1.9
 libssh2:
   - 1.8
 libsvm:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.03.17" %}
+{% set version = "2019.03.18" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Goes together with https://github.com/conda-forge/libspatialindex-feedstock/pull/18.

We are not pinning libspatialindex at the moment and everything build with `1.8.5` may be broken once we merge https://github.com/conda-forge/libspatialindex-feedstock/pull/18. I guess we need to do a repo patch in this case. Unless someone has a better idea...