### PR TITLE
Use NMake instead of visual studio generator

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -57,6 +57,8 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
+CMAKE_GENERATOR:               # [win]
+  - NMake Makefiles            # [win]
 #
 # Go Compiler Options
 #

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.04.18" %}
+{% set version = "2019.04.24" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Depends on https://github.com/AnacondaRecipes/aggregate/pull/138

@scopatz, @mariusvniekerk, if the above PR is merged and released and this PR is merged, we'll have working cmake VS2015 on azure.