### PR TITLE
re-pin geotiff

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -185,7 +185,7 @@ pin_run_as_build:
   geos:
     max_pin: x.x.x
   geotiff:
-    max_pin: x.x
+    max_pin: x.x.x
   glew:
     max_pin: x.x
   glpk:
@@ -396,7 +396,7 @@ gdal:
 geos:
   - 3.7.1
 geotiff:
-  - 1.4.2
+  - 1.5.1
 giflib:
   - 5.1.7
 glew:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.04.11" %}
+{% set version = "2019.04.12" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Even though the geotiff 1.4 series was OK with the x.x pin I decided to be more conservative here to avoid headaches. We don't have ABI info on the 1.5.x series.

Pinging @hobu who may have more info on the ABI compatibility. See https://abi-laboratory.pro/?view=timeline&l=libgeotiff for the past info.