### PR TITLE
pin zeromq 4.3.1 on all platforms

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -574,8 +574,7 @@ xerces_c:
 xz:
   - 5.2
 zeromq:
-  - 4.2.5  # [not (aarch64 or ppc64le)]
-  - 4.3.1  # [aarch64 or ppc64le]
+  - 4.3.1
 zlib:
   - 1.2
 zstd:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.04.12" %}
+{% set version = "2019.04.18" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
will need rebuilds of packages pinning 4.2.x<y<4.3.0

Fixes CVE-2019-6250

cc @dhirschfeld