### PR TITLE
pin qt

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -542,9 +542,9 @@ python:
   - 3.6
   - 3.7
 pyqt:
-  - 5.6
+  - 5.9
 qt:
-  - 5.6
+  - 5.9
 readline:
   - 7.0
 r_base:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.04.24" %}
+{% set version = "2019.04.30" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.04.18" %}
+{% set version = "2019.04.24" %}
 
 package:
   name: conda-forge-pinning
@@ -20,7 +20,7 @@ test:
 
 about:
   summary: The baseline versions of software for the conda-forge ecosystem
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   home: https://conda-forge.org/docs/meta.html#pinning-packages
 


### PR DESCRIPTION
~~# DO NOT MERGE YET!!!~~

~~We need to finish https://github.com/conda-forge/qt-feedstock/pull/103 first.~~

That is done! We have `qt 5.9.7` with latest `openssl` for all three main platforms (Windows, Linux, and macOS).