### PR TITLE
pin min numpy to 1.14.*

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -514,12 +514,9 @@ nlopt:
   - 2.6.*
 ntl:
   - 11.3.1
-# we build for an old version of numpy for forward compatibility
-#    1.11 seems to be the oldest on win that works with scipy 0.19.  Compiler errors otherwise.
+# we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  - 1.9    # [linux64 or osx]
-  - 1.11   # [aarch64 or ppc64le]
-  - 1.11   # [win]
+  - 1.14
 occt:
   - 7.3
 openblas:


### PR DESCRIPTION
Using the oldest `numpy` possible is a big advantage for good forward compatibility. However, scipy (and I believe some functionalities of `scikit-learn`) demand a newer `numpy` at build time (1.13). Also, we are already using `numpy 1.14` on Windows and `1.14` for `scipy` on Python 3.7 b/c there are no older viable version available. So, to make things simpler as we move forward, I propose we change the global pining to `1.14` everywhere.