### PR TITLE
we don't have numpy 1.14 on aarch64 or ppc64le

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -516,7 +516,8 @@ ntl:
   - 11.3.1
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  - 1.14
+  - 1.14       # [not (aarch64 or ppc64le)]
+  - 1.16       # [aarch64 or ppc64le]
 occt:
   - 7.3
 openblas:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.05.25" %}
+{% set version = "2019.05.26" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

### Migration
<!--
If this is an ABI incompatible change which requries a migration, please note it and ping ``@conda-forge/bot``.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
