### PR TITLE
update hdf5 pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -418,7 +418,7 @@ harfbuzz:
 hdf4:
   - 4.2
 hdf5:
-  - 1.10.4
+  - 1.10.5
 icu:
   - 58   # [not aarch64]
   - 60   # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.05.31" %}
+{% set version = "2019.06.05" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
This will allow us to start using the `mpi` variants in envs.
I'll set a migrator after this is merged.