### PR TITLE
drop pin for pyqt

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -127,7 +127,6 @@ build_number_decrement:                         # [(linux64 or osx)     and (env
 
 zip_keys:
   -
-    - pyqt
     - qt
   -
     - python
@@ -308,8 +307,6 @@ pin_run_as_build:
     max_pin: x.x
   proj4:
     max_pin: x.x.x
-  pyqt:
-    max_pin: x.x
   qt:
     max_pin: x.x
   readline:
@@ -543,8 +540,6 @@ python:
   - 2.7
   - 3.6
   - 3.7
-pyqt:
-  - 5.9
 qt:
   - 5.9
 readline:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.06.05" %}
+{% set version = "2019.06.06" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Pinning `pyqt` was a legacy workaround from conda-build 2 times and I believe that today it causes more harm than good, like preventing us from choosing pyqt 4 or 5 on packages that work with both.