### PR TITLE
Pixman aarch64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -531,8 +531,7 @@ pango:
 perl:
   - 5.26
 pixman:
-  - 0.34  # [not (aarch64 or ppc64le)]
-  - 0.38  # [aarch64 or ppc64le]
+  - 0.38
 poppler:
   - 0.67.0
 proj4:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -531,7 +531,8 @@ pango:
 perl:
   - 5.26
 pixman:
-  - 0.34
+  - 0.34  # [not (aarch64 or ppc64le)]
+  - 0.38  # [aarch64 or ppc64le]
 poppler:
   - 0.67.0
 proj4:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.06.06" %}
+{% set version = "2019.06.09" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
xref: https://github.com/conda-forge/cairo-feedstock/pull/48


tjakob
@tjakob
Jun 07 10:41
> Hi all, as part of the migration effort I start to look at cairo (conda-forge/cairo-feedstock#48). It is building fine for POWER, but failing on x86 and aarch64. For x86, change the gcc version to 5.4 makes it work, and the aarch64 build needs pixman 0.38 (as 0.34 is not available)
How would I go about updating the version dependencies?


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
