### PR TITLE
Pin libevent to 2.1.10 on aarch64 and ppc64le

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -442,7 +442,8 @@ libcurl:
 libdap4:
   - 3.19
 libevent:
-  - 2.0.22
+  - 2.0.22   # [not (aarch64 or ppc64le)]
+  - 2.1.10   # [aarch64 or ppc64le]
 libffi:
   - 3.2
 libgdal:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -442,8 +442,7 @@ libcurl:
 libdap4:
   - 3.19
 libevent:
-  - 2.0.22   # [not (aarch64 or ppc64le)]
-  - 2.1.10   # [aarch64 or ppc64le]
+  - 2.1.10
 libffi:
   - 3.2
 libgdal:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.06.09" %}
+{% set version = "2019.06.17" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
No need to write a migrator as this will be covered by the Arch Migrator.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
