### PR TITLE
Update libprotobuf pin to 3.8

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -459,7 +459,7 @@ libpng:
   - 1.6.35   # [not (aarch64 or ppc64le)]
   - 1.6.36   # [aarch64 or ppc64le]
 libprotobuf:
-  - 3.7
+  - 3.8
 librdkafka:
   - 0.11.5
 librsvg:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.06.19" %}
+{% set version = "2019.06.27" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
This is the first version built for aarch64/ppc64le

Migrator: https://github.com/regro/cf-scripts/pull/530