### PR TITLE
Update Pango to the 1.42 series

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -524,7 +524,7 @@ openssl:
 openturns:
   - 1.13*
 pango:
-  - 1.40
+  - 1.42
 pari:
   - 2.11
 perl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.07.10" %}
+{% set version = "2019.07.13" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
The current build of the 1.42.4 is not available on aarch64/ppc64le, but should become available once a PR to add these arches for the new dependency fribidi is merged (conda-forge/fribidi-feedstock#2). This should happen quickly, I hope, but this could conceivably block the addition of the new arches to some packages.