### PR TITLE
Allow patch-level updates for libxml2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -478,7 +478,7 @@ libunwind:
 libwebp:
   - 1.0.0
 libxml2:
-  - 2.9
+  - 2.9.*
 libuuid:
   - 2.32.1
 lz4_c:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.07.20" %}
+{% set version = "2019.07.22" %}
 
 
 package:


### PR DESCRIPTION
See https://abi-laboratory.pro/?view=timeline&l=libxml2, updating on the patch level should be safe enough to open up the pin.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
