### PR TITLE
Use latest libpng

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -466,8 +466,7 @@ libnetcdf:
 libpcap:
   - 1.8
 libpng:
-  - 1.6.35   # [not (aarch64 or ppc64le)]
-  - 1.6.36   # [aarch64 or ppc64le]
+  - 1.6
 libprotobuf:
   - 3.8
 librdkafka:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.08.08" %}
+{% set version = "2019.08.09" %}
 
 
 package:


### PR DESCRIPTION
So that latest features can be used by projects. No need of a migrator as the pin is `x.x`

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
