### PR TITLE
update gdal pin to 3.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -400,7 +400,7 @@ gstreamer:
 gst_plugins_base:
   - 1.14.4
 gdal:
-  - 2.4
+  - 3.0
 geos:
   - 3.7.2
 geotiff:
@@ -454,7 +454,7 @@ libevent:
 libffi:
   - 3.2
 libgdal:
-  - 2.4
+  - 3.0
 libiconv:
   - 1.15
 libkml:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.08.09" %}
+{% set version = "2019.08.11" %}
 
 
 package:


### PR DESCRIPTION
With the new `rasterio` only `cartopy` is lagging behind but it is OK to start pinning to the latest `gdal`.