### PR TITLE
Add proj pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -310,8 +310,6 @@ pin_run_as_build:
     max_pin: x.x
   poppler:
     max_pin: x.x
-  proj4:
-    max_pin: x.x.x
   qt:
     max_pin: x.x
   readline:
@@ -561,6 +559,8 @@ poppler:
   - 0.67.0
 proj4:
   - 6.1.1
+proj:
+  - 6.2.0
 python:
   - 2.7
   - 3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.09.08" %}
+{% set version = "2019.09.24" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Once we fix all the feedstocks we can remove the `proj4` name from the pinning scheme.

Ping @snowman2 