### PR TITLE
Drop old compilers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,6 @@ cross_compiler_target_platform:  # [win]
   - win-64                     # [win]
 c_compiler:
   # legacy compilers for things that refuse to move
-  - toolchain_c                # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   # modern compilers
   - gcc                        # [linux64]
   - clang                      # [osx]
@@ -19,13 +18,10 @@ c_compiler:
   - vs2015                     # [win]
   - vs2015                     # [win]
 c_compiler_version:            # [unix]
-  - 2                          # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   - 4                          # [osx]
   - 7                          # [linux64 or aarch64]
   - 8                          # [ppc64le or armv7l]
 cxx_compiler:
-  # legacy compilers for things that refuse to move
-  - toolchain_cxx              # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   # modern compilers
   - gxx                        # [linux64]
   - clangxx                    # [osx]
@@ -38,17 +34,14 @@ cxx_compiler:
   - vs2015                     # [win]
   - vs2015                     # [win]
 cxx_compiler_version:          # [unix]
-  - 2                          # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   - 4                          # [osx]
   - 7                          # [linux64 or aarch64]
   - 8                          # [ppc64le or armv7l]
 fortran_compiler:              # [unix or win64]
-  - toolchain_fort             # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   - gfortran                   # [(linux64 or osx)]
   - gfortran                   # [aarch64 or ppc64le or armv7l]
   - flang                      # [win64]
 fortran_compiler_version:      # [unix or win64]
-  - 2                          # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
   - 4                          # [osx]
   - 7                          # [linux64 or osx or aarch64]
   - 8                          # [ppc64le or armv7l]
@@ -111,23 +104,16 @@ channel_sources:
   - conda-forge,defaults                        # [not (aarch64 or armv7l)]
   - conda-forge,c4aarch64,defaults              # [aarch64]
   - conda-forge,c4armv7l,defaults               # [armv7l]
-  - conda-forge/label/cf201901,defaults         # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
 
 channel_targets:
   - conda-forge main
-  - conda-forge cf201901                        # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
 
 docker_image:                                   # [linux]
   - condaforge/linux-anvil-comp7                # [linux64]
-  - condaforge/linux-anvil                      # [linux64              and (environ.get('CF_COMPILER_STACK') == 'comp4')]
 
   - condaforge/linux-anvil-aarch64              # [aarch64]
   - condaforge/linux-anvil-ppc64le              # [ppc64le]
   - condaforge/linux-anvil-armv7l               # [armv7l]
-
-build_number_decrement:                         # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-  - 1000                                        # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-  - 0                                           # [(linux64 or osx)     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
 
 zip_keys:
   -
@@ -137,16 +123,6 @@ zip_keys:
     - vc                        # [win]
     - c_compiler                # [win]
     - cxx_compiler              # [win]
-
-  # Dual compiler zip
-  -                             # [                                         (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - c_compiler                # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - cxx_compiler              # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - fortran_compiler          # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - channel_sources           # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - channel_targets           # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - docker_image              # [linux64                              and (environ.get('CF_COMPILER_STACK') == 'comp4')]
-    - build_number_decrement    # [(linux64 or osx)                     and (environ.get('CF_COMPILER_STACK') == 'comp4')]
 
 # aarch64 specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.09.25" %}
+{% set version = "2019.09.27" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
As the compiler migration has been completed for a while, go ahead and clean out these legacy bits needed for the older compiler stack.

cc @conda-forge/core

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
