### PR TITLE
Make maintainers the core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CJ-Wright @isuruf @jakirkham @msarahan @ocefpaf @pelson
+* @conda-forge/Core

--- a/README.md
+++ b/README.md
@@ -116,10 +116,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@CJ-Wright](https://github.com/CJ-Wright/)
-* [@isuruf](https://github.com/isuruf/)
-* [@jakirkham](https://github.com/jakirkham/)
-* [@msarahan](https://github.com/msarahan/)
-* [@ocefpaf](https://github.com/ocefpaf/)
-* [@pelson](https://github.com/pelson/)
+* [@conda-forge/Core](https://github.com/conda-forge/Core/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - isuruf
-    - jakirkham
-    - msarahan
-    - ocefpaf
-    - pelson
-    - CJ-Wright
+    - conda-forge/Core


### PR DESCRIPTION
Updates the feedstock maintainers to just be the core team.

cc @conda-forge/core

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
