### PR TITLE
Add the CUDA compiler

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -40,6 +40,15 @@ m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
 CMAKE_GENERATOR:               # [win]
   - NMake Makefiles            # [win]
+
+cuda_compiler:                 # [linux64]
+  - nvcc                       # [linux64]
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+
 #
 # Go Compiler Options
 #
@@ -96,6 +105,9 @@ channel_targets:
 
 docker_image:                                   # [linux]
   - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
 
   - condaforge/linux-anvil-aarch64              # [aarch64]
   - condaforge/linux-anvil-ppc64le              # [ppc64le]
@@ -109,6 +121,9 @@ zip_keys:
     - vc                        # [win]
     - c_compiler                # [win]
     - cxx_compiler              # [win]
+  -                             # [linux64]
+    - cuda_compiler_version     # [linux64]
+    - docker_image              # [linux64]
 
 # aarch64 specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.10.08" %}
+{% set version = "2019.10.11" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Note: This is still a work-in-progress and still needs some changes.

This adds the CUDA compiler to conda-forge. It works by allowing users to require the CUDA compiler during their build. When this happens in a feedstock, we leveraging the conda-forge Docker images (based off of NVIDIA's Docker images), which contain the NVCC toolchain. These Docker images are selected with a version matching that of CUDA compiler requested by the user. We set the supported CUDA versions (and Docker images that match) much like we do with Python. Additionally users can also have a CPU only build, which is useful for packages that have CPU and GPU builds.

On testing this works fine for things like [the ucx build]( https://github.com/conda-forge/ucx-split-feedstock ), but is still a little odd for non-GPU builds. So likely needs some work to preserve the same behavior for existing feedstocks.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/237
<!--
Please add any other relevant info below:
-->
