### PR TITLE
migrator for mpich 3.3

### DIFF
--- a/recipe/migrations/mpich-3.3.yaml
+++ b/recipe/migrations/mpich-3.3.yaml
@@ -1,0 +1,17 @@
+# To learn more about migrations read CFEP-09
+# https://github.com/conda-forge/conda-forge-enhancement-proposals/blob/master/cfep-09.md
+# The timestamp of when the migration was made
+# Can be obtained by copying the output of
+# python -c "import time; print(f'{time.time():.0f}')"
+migrator_ts: 1571312255
+__migrator:
+  kind:
+    version
+  # Only change the migration_number if the bot messes up,
+  # changing this will cause a complete rerun of the migration
+  migration_number:
+    1
+
+# The name of the feedstock you wish to migrate
+mpich:
+  - 3.3    # new version to build against


### PR DESCRIPTION
this version is already pinned in conda_build_config.yaml, but several packages were not rebuilt due to multiple outputs (e.g. ptscotch). I'm not sure if the new migrators work when the new version is already in the pins, even though there are still packages that need rebuilding, but this should tell us.