### PR TITLE
Disable python 2.7 for ppc64le and aarch64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -547,7 +547,7 @@ proj4:
 proj:
   - 6.2.0
 python:
-  - 2.7
+  - 2.7  # [not (aarch64 or ppc64le)]
   - 3.6
   - 3.7
 qt:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.10.11" %}
+{% set version = "2019.10.21" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
We didn't build scipy for python 2.7
It seems that we are running the clock on 2019 anyway. 
Marius would have called this back in 2018 when we started this project ;)


cc: @mariusvniekerk 
@conda-forge/arm-arch 


Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
