### PR TITLE
Set minimum version of NCCL to 2.4.6.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -492,6 +492,8 @@ mumps_mpi:
   - 5.2
 mumps_seq:
   - 5.2
+nccl:
+  - 2.4.6.1
 ncurses:
   - 6.1
 netcdf_cxx4:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.10.11" %}
+{% set version = "2019.10.22" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
The `max_pin` of `nccl` is set to `x` already in the recipe [using this `run_exports` line]( https://github.com/conda-forge/nccl-feedstock/blob/db95a970c6d4ed74873822ffd30e7c2fcff001a3/recipe/meta.yaml#L23-L25 ). This follows the compatibility guidance we were given in issue ( https://github.com/NVIDIA/nccl/issues/218 ).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
