### PR TITLE
add arrow pin

### DIFF
--- a/recipe/migrations/arrow-cpp-0.15.yaml
+++ b/recipe/migrations/arrow-cpp-0.15.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1571940392
+__migrator:
+  kind:
+    version
+# This is a new pin but it has run_exports to "x.x"
+
+arrow-cpp:
+  - 0.15


### PR DESCRIPTION
This is a novel pin: [ABI lab](https://abi-laboratory.pro/index.php?view=timeline&l=apache-arrow)

The recipe has a `run_exports` set to `x.x`.

Attn:
@conda-forge/arrow-cpp
@jakirkham