### PR TITLE
update libspatialindex pin due to soname change

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -236,8 +236,6 @@ pin_run_as_build:
     max_pin: x.x.x
   librsvg:
     max_pin: x
-  libspatialindex:
-    max_pin: x.x
   libssh2:
     max_pin: x.x
   libsvm:

--- a/recipe/migrations/libspatialindex-1.9.2.yaml
+++ b/recipe/migrations/libspatialindex-1.9.2.yaml
@@ -1,0 +1,17 @@
+# To learn more about migrations read CFEP-09
+# https://github.com/conda-forge/conda-forge-enhancement-proposals/blob/master/cfep-09.md
+# The timestamp of when the migration was made
+# Can be obtained by copying the output of
+# python -c "import time; print(f'{time.time():.0f}')"
+migrator_ts: 1572370591
+__migrator:
+  kind:
+    version
+  # Only change the migration_number if the bot messes up,
+  # changing this will cause a complete rerun of the migration
+  migration_number:
+    1
+
+# The name of the feedstock you wish to migrate
+libspatialindex:
+  - 1.9.3


### PR DESCRIPTION
The soname in `libspatialindex` 1.9.0 is `libspatialindex.so.5` but was updated to `libspatialindex.so.6` in 1.9.1. We probably need to do a hotfix and a new migrator. I'll try to finish this tomorrow, if not only when I get back from the NumFOCUS summit.

xref.: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/315