### PR TITLE
Add a migrator for arrow-cpp 0.15.1

### DIFF
--- a/recipe/migrations/arrow_0.15.1.yaml
+++ b/recipe/migrations/arrow_0.15.1.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1573578499
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+
+arrow_cpp:
+  - 0.15.1


### PR DESCRIPTION
Partially addresses issue ( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/321 )

Adds a migrator to update `arrow-cpp` to version `0.15.1`. The package also has `run_exports`.

cc @conda-forge/arrow-cpp @kkraus14 @mike-wendt @CJ-Wright 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
