### PR TITLE
Bump arrow-cpp 0.15.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -346,7 +346,7 @@ blas_impl:
 arpack:
   - 3.6.3
 arrow_cpp:
-  - 0.15.0
+  - 0.15.1
 boost:
   - 1.70.0
 boost_cpp:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.11.13" %}
+{% set version = "2019.11.14" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/migrations/arrow_0.15.1.yaml
+++ b/recipe/migrations/arrow_0.15.1.yaml
@@ -1,9 +1,0 @@
-migrator_ts: 1573578499
-__migrator:
-  kind:
-    version
-  migration_number:
-    1
-
-arrow_cpp:
-  - 0.15.1


### PR DESCRIPTION
Completes the `arrow-cpp` version `0.15.1` migration and bumps the `arrow-cpp` pin accordingly.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering): Done in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/331 ).
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/321

<!--
Please add any other relevant info below:
-->
