### PR TITLE
migrate to libtiff 4.1.0

### DIFF
--- a/recipe/migrations/libtiff-4.1.0.yaml
+++ b/recipe/migrations/libtiff-4.1.0.yaml
@@ -1,0 +1,22 @@
+# To learn more about migrations read CFEP-09
+# https://github.com/conda-forge/conda-forge-enhancement-proposals/blob/master/cfep-09.md
+# The timestamp of when the migration was made
+# Can be obtained by copying the output of
+# python -c "import time; print(f'{time.time():.0f}')"
+migrator_ts: 1574163185
+__migrator:
+  kind:
+    version
+  # Only change the migration_number if the bot messes up,
+  # changing this will cause a complete rerun of the migration
+  migration_number:
+    1
+  # This determines the increment to the build number when the
+  # migration runs.
+  # Change this to zero if the new pin increases the number of builds
+  build_number:
+    1
+
+# The name of the feedstock you wish to migrate
+libtiff:
+  - 4.1.0    # new version to build against


### PR DESCRIPTION
I did send PR https://github.com/conda-forge/libtiff-feedstock/pull/47 to help with the old pin situation but ideally we should just move to the new version of the package to avoid breakages in the future.