### PR TITLE
update suitesparse migration to 5.6

### DIFF
--- a/recipe/migrations/suitesparse-5.6.yaml
+++ b/recipe/migrations/suitesparse-5.6.yaml
@@ -3,7 +3,7 @@
 # The timestamp of when the migration was made
 # Can be obtained by copying the output of
 # python -c "import time; print(f'{time.time():.0f}')"
-migrator_ts: 1574159508
+migrator_ts: 1574175506
 __migrator:
   kind:
     version
@@ -19,4 +19,4 @@ __migrator:
 
 # The name of the feedstock you wish to migrate
 suitesparse:
-  - 5.4    # new version to build against
+  - 5.6    # new version to build against


### PR DESCRIPTION
I'm not sure if this is the right way to do what I want, but here's hoping.

SuiteSparse has had a 5.6 release since the 5.4 migration started.

My goal:

- end the 5.4 migration
- supersede with a new migration to 5.6

To which end I removed the suitesparse-5.4 migrator and added a 5.6 migrator with new timestamp and version number. I'm hoping this accomplishes what I'm after, but I'm not sure.

cc @CJ-Wright