### PR TITLE
End protobuf 3.10 migration, start 3.11

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -458,7 +458,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - 3.8
+  - 3.10
 librdkafka:
   - 0.11.5
 librsvg:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.11.20" %}
+{% set version = "2019.11.26" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/migrations/protobuf311.yaml
+++ b/recipe/migrations/protobuf311.yaml
@@ -3,7 +3,7 @@
 # The timestamp of when the migration was made
 # Can be obtained by copying the output of
 # python -c "import time; print(f'{time.time():.0f}')"
-migrator_ts: 1572797096
+migrator_ts: 1574770367
 __migrator:
   kind:
     version
@@ -15,4 +15,4 @@ __migrator:
     1
 # The name of the feedstock you wish to migrate
 libprotobuf:
-  - 3.10
+  - 3.11


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Will close the following PRs after merge: https://github.com/conda-forge/shogun-cpp-feedstock/pull/31 and https://github.com/conda-forge/mosh-feedstock/pull/14
