### PR TITLE
Change python order to give higher versions priority

### DIFF
--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,9 +7,9 @@ cross_compiler_target_platform:  # [win]
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
   - vs2008                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
 c_compiler_version:            # [unix]
   - 9                          # [osx]
   - 7                          # [linux64 or aarch64]
@@ -17,9 +17,9 @@ c_compiler_version:            # [unix]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
   - vs2008                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
 cxx_compiler_version:          # [unix]
   - 9                          # [osx]
   - 7                          # [linux64 or aarch64]
@@ -555,9 +555,9 @@ proj4:
 proj:
   - 6.2.1
 python:
-  - 2.7  # [not (aarch64 or ppc64le)]
-  - 3.6
   - 3.7
+  - 3.6
+  - 2.7  # [not (aarch64 or ppc64le)]
 qt:
   - 5.12
 readline:
@@ -587,9 +587,9 @@ tk:
 tiledb:
   - 1.7.0
 vc:                    # [win]
+  - 14                 # [win]
+  - 14                 # [win]
   - 9                  # [win]
-  - 14                 # [win]
-  - 14                 # [win]
 vlfeat:
   - 0.9.20
 vtk:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2019.11.26" %}
+{% set version = "2019.11.27" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ about:
   summary: The baseline versions of software for the conda-forge ecosystem
   license: BSD-3-Clause
   license_family: BSD
-  license_file: ../LICENSE.txt
+  license_file: LICENSE.txt
   home: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-pinning
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ about:
   summary: The baseline versions of software for the conda-forge ecosystem
   license: BSD-3-Clause
   license_family: BSD
+  license_file: ../LICENSE.txt
   home: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-pinning
 
 extra:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

`conda-build`/`conda-smithy` like to prefer the first entry in the version list.
Hence it makes sense to put `2.7` at the end since we usually don't need that old stuff.

Unblocks https://github.com/conda-forge/divebomb-feedstock/pull/13.
