### PR TITLE
Drop sundials pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -309,8 +309,6 @@ pin_run_as_build:
     max_pin: x.x.x
   sqlite:
     max_pin: x
-  sundials:
-    max_pin: x.x
   tk:
     max_pin: x.x
   tiledb:
@@ -592,8 +590,6 @@ sox:
   - 14.4.2
 sqlite:
   - 3
-sundials:
-  - 3.2
 suitesparse:
   - 5.6
 tk:


### PR DESCRIPTION
useless now that assimulo is compatible with >=4

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
