### PR TITLE
Add CUDA 10.2 migration

### DIFF
--- a/recipe/migrations/cuda102.yaml
+++ b/recipe/migrations/cuda102.yaml
@@ -24,3 +24,5 @@ docker_image:                                   # [linux]
   - condaforge/linux-anvil-aarch64              # [aarch64]
   - condaforge/linux-anvil-ppc64le              # [ppc64le]
   - condaforge/linux-anvil-armv7l               # [armv7l]
+
+cuda_compiler_stub: none

--- a/recipe/migrations/cuda102.yaml
+++ b/recipe/migrations/cuda102.yaml
@@ -1,0 +1,26 @@
+migrator_ts: 1576782497
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    0
+
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]


### PR DESCRIPTION
Creates a migration to add CUDA 10.2 to the build matrix of CUDA compiled packages.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
