### PR TITLE
Include CUDA 10.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -48,6 +48,7 @@ cuda_compiler_version:         # [linux64]
   - 9.2                        # [linux64]
   - 10.0                       # [linux64]
   - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
 
 _libgcc_mutex:
   - 0.1 conda_forge
@@ -118,6 +119,7 @@ docker_image:                                   # [linux]
   - condaforge/linux-anvil-cuda:9.2             # [linux64]
   - condaforge/linux-anvil-cuda:10.0            # [linux64]
   - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
 
   - condaforge/linux-anvil-aarch64              # [aarch64]
   - condaforge/linux-anvil-ppc64le              # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
Adds CUDA 10.2 to the matrix of CUDA versions that are built against.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
