### PR TITLE
Added httplib2 to enable it for ppc64le architecture

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -66,3 +66,4 @@ nano
 python-symengine
 file
 hub
+httplib2


### PR DESCRIPTION
Request to enable https://github.com/conda-forge/httplib2-feedstock for ppc64le architecture.