### PR TITLE
Pin arb to latest stable version

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -351,6 +351,8 @@ blas_impl:
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
+arb:
+  - 2.17.0
 arpack:
   - 3.6.3
 arrow_cpp:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -352,7 +352,7 @@ blas_impl:
   - blis         # [x86 or x86_64]
 
 arb:
-  - 2.17.0
+  - 2.17
 arpack:
   - 3.6.3
 arrow_cpp:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.01.24" %}
+{% set version = "2020.01.27" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Arb is a C library for ball arithmetic.

It's currently only used in sage/sagelib, e-antic, python-flint, and numcosmo. Recursively, normaliz, (and maybe gap, and libgap) depend on arb through e-antic.

Therefore, I don't think a migration is worth it. If you don't mind, I'll just create the PRs for these manually since I am a maintainer of most anyway.