### PR TITLE
Add migration for gsl=2.6

### DIFF
--- a/recipe/migrations/gsl26.yaml
+++ b/recipe/migrations/gsl26.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1580917198
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+gsl:
+  - 2.6


### PR DESCRIPTION
ABI breaking, so we need to migrate: https://abi-laboratory.pro/?view=timeline&l=gsl