### PR TITLE
Fix boost(-cpp) 1.72 migration

### DIFF
--- a/recipe/migrations/boost172.yaml
+++ b/recipe/migrations/boost172.yaml
@@ -3,9 +3,11 @@ __migrator:
   kind:
     version
   migration_number:
-    1
+    2
   build_number:
     1
+boost:
+  - 1.72
 boost_cpp:
   - 1.72
 


### PR DESCRIPTION
`boost` and `boost-cpp` need to be migrated at the same time.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
