### PR TITLE
migrate to proj 6.3.1

### DIFF
--- a/recipe/migrations/proj631.yaml
+++ b/recipe/migrations/proj631.yaml
@@ -1,0 +1,23 @@
+# To learn more about migrations read CFEP-09
+# https://github.com/conda-forge/conda-forge-enhancement-proposals/blob/master/cfep-09.md
+# The timestamp of when the migration was made
+# Can be obtained by copying the output of
+# python -c "import time; print(f'{time.time():.0f}')"
+migrator_ts: 1582576332
+__migrator:
+  kind:
+    version
+  # Only change the migration_number if the bot messes up,
+  # changing this will cause a complete rerun of the migration
+  migration_number:
+    1
+  # This determines the increment to the build number when the 
+  # migration runs. 
+  # Change this to zero if the new pin increases the number of builds
+  build_number:
+    1
+
+# The name of the feedstock you wish to migrate with dashes replaced by
+# underscores
+proj:
+  - 6.3.1    # new version to build against


### PR DESCRIPTION
We still have a tight `x.x.x` pin due to https://abi-laboratory.pro/?view=timeline&l=proj. Hopefully we'll be able to relax that pin with `proj 7.0`.