### PR TITLE
Fix root-binaries package name in migration and pinning list

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -571,7 +571,7 @@ root:
   - 6.18.04
 root_base:
   - 6.18.04
-root_binaries:
+root-binaries:
   - 6.18.04
 ruby:
   - 2.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.02.20" %}
+{% set version = "2020.03.03" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/migrations/root620000.yaml
+++ b/recipe/migrations/root620000.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    2
+    1
   build_number:
     1
 

--- a/recipe/migrations/root620000.yaml
+++ b/recipe/migrations/root620000.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    1
+    2
   build_number:
     1
 
@@ -11,5 +11,5 @@ root:
   - 6.20.0
 root_base:
   - 6.20.0
-root_binaries:
+root-binaries:
   - 6.20.0


### PR DESCRIPTION
This PR corrects the package name for `root-binaries`, which was previously incorrectly listed as `root_binaries` in both the root-62000 migration, and the `conda_build_config.yaml` pinning list.

cc @chrisburr

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
