### PR TITLE
Remove redundant root pins

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -567,11 +567,7 @@ qt:
   - 5.12
 readline:
   - 8.0
-root:
-  - 6.18.04
 root_base:
-  - 6.18.04
-root_binaries:
   - 6.18.04
 ruby:
   - 2.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.02.20" %}
+{% set version = "2020.03.03" %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
`root` and `root-binaries` are pinned to `root_base` in their builds, so we only need to pin the base package.

cc @chrisburr, @beckermr

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
