### PR TITLE
Update root620000 migration to only update root_base

### DIFF
--- a/recipe/migrations/root620000.yaml
+++ b/recipe/migrations/root620000.yaml
@@ -7,9 +7,5 @@ __migrator:
   build_number:
     1
 
-root:
-  - 6.20.0
 root_base:
-  - 6.20.0
-root_binaries:
   - 6.20.0


### PR DESCRIPTION
This PR updates the root620000 migration (#410) to only update the `root_base` package (see #414)

cc: @chrisburr @beckermr 


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
