### PR TITLE
Pin abseil-cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -153,6 +153,8 @@ BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
 # TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:
+  abseil-cpp:
+    max_pin: x.x
   arpack:
     max_pin: x.x.x
   boost:
@@ -349,6 +351,8 @@ blas_impl:
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
+abseil-cpp:
+  - 20190808.0
 arb:
   - 2.17
 arpack:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -351,7 +351,7 @@ blas_impl:
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
-abseil-cpp:
+abseil_cpp:
   - 20190808.0
 arb:
   - 2.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX      # [unix]


### PR DESCRIPTION
Abseil has no ABI compatability at all: https://abseil.io/about/compatibility

Respective repodata patching: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/34

Once this and the repodata patch is merged, I will merge https://github.com/conda-forge/abseil-cpp-feedstock/pull/9 and start a migration to the new version.