### PR TITLE
Add python-annoy to migrators, few others

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -94,3 +94,6 @@ zopfli
 jxrlib
 lld
 radical.utils
+python-annoy
+xorg-damageproto
+xorg-xf86vidmodeproto


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


This adds a few packages to the arch migrator:
python-annoy
xorg-damageproto
xorg-xf86vidmodeproto
