### PR TITLE
BUG exclude cpython only package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2020.03.12" %}
+{% set version = "2020.03.13" %}
 
 package:
   name: conda-forge-pinning

--- a/recipe/migrations/pypy.yaml
+++ b/recipe/migrations/pypy.yaml
@@ -5,6 +5,8 @@ __migrator:
   migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
     1
   bump_number: 1   # Hashes changed for cpython, so it's better to bump build numbers.
+  exclude:
+    - fastcache
 
 python:
   - 2.7.* *_cpython   # [not (aarch64 or ppc64le)]


### PR DESCRIPTION
We currently don't have good metadata on which packages are cpython only. For now, it may make sense to exclude them by hand.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
