### PR TITLE
Exclude root from ROOT migration

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S') %}
+{#% set version = datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S') %#}
+{% set version = '2020.03.24' %}
 
 package:
   name: conda-forge-pinning
@@ -8,7 +9,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX                       # [unix]

--- a/recipe/migrations/root_base6202.yaml
+++ b/recipe/migrations/root_base6202.yaml
@@ -1,6 +1,8 @@
 __migrator:
   build_number: 1
   kind: version
+  exclude:
+    - root
   migration_number: 1
 migrator_ts: 1584431816.6031702
 root_base:


### PR DESCRIPTION
The `root_base` migration is stuck waiting the package which it's an output of to be updated. I'll make a PR to conda-smithy to fix it but for now just add it to the excluded packages.

I guess the version no longer needs to be updated manually on this feedstock as it seems to use the current time?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
