### PR TITLE
Pin fmt library

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -169,8 +169,6 @@ pin_run_as_build:
     max_pin: x
   flann:
     max_pin: x.x.x
-  fmt:
-    max_pin: x
   fontconfig:
     max_pin: x
   freetype:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -169,6 +169,8 @@ pin_run_as_build:
     max_pin: x
   flann:
     max_pin: x.x.x
+  fmt:
+    max_pin: x
   fontconfig:
     max_pin: x
   freetype:
@@ -372,6 +374,8 @@ fftw:
   - 3
 flann:
   - 1.9.1
+fmt:
+  - 6
 fontconfig:
   - 2.13
 freetype:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {#% set version = datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S') %#}
-{% set version = '2020.03.24' %}
+{% set version = '2020.03.26' %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
fmt is a shared C++ library. Upstream seems to be quite strict about ABI compatibility so pinning to the major version appears to be good enough to me.