### PR TITLE
No R 3.5 for aarch64 or ppc64le

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -573,7 +573,7 @@ ruby:
   - 2.5
   - 2.6
 r_base:
-  - 3.5.1
+  - 3.5.1             # [not (aarch64 or ppc64le)]
   - 3.6
 scotch:
   - 6.0.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {#% set version = datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S') %#}
-{% set version = '2020.04.06' %}
+{% set version = '2020.04.07' %}
 
 package:
   name: conda-forge-pinning


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

R-base is now enabled for aarch64 and ppc64le at version 3.6.3.
r-base 3.5.1 won't ever be built, so this will avoid that build config.