### PR TITLE
pin libwebp-base instead of libwebp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -479,9 +479,9 @@ libtiff:
 libunwind:
   - 1.2
 libwebp:
-  - 1.0
+  - 1.1
 libwebp_base:
-  - 1.0
+  - 1.1
 libxml2:
   - 2.9
 libuuid:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -241,8 +241,6 @@ pin_run_as_build:
     max_pin: x.x
   libtiff:
     max_pin: x
-  libwebp:
-    max_pin: x.x
   libxml2:
     max_pin: x.x
   libuuid:
@@ -480,7 +478,7 @@ libtiff:
   - 4.1.0
 libunwind:
   - 1.2
-libwebp:
+libwebp_base:
   - 1.0
 libxml2:
   - 2.9

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -478,6 +478,8 @@ libtiff:
   - 4.1.0
 libunwind:
   - 1.2
+libwebp:
+  - 1.0
 libwebp_base:
   - 1.0
 libxml2:


### PR DESCRIPTION
I believe that only `gdal` is pinning `libwebp` at the moment so we probably don't need a migration. Also, I removed the `x.x` b/c we have run_exports on the feedstock.

@isuruf do you mind taking a quick look? I'm not bumping the version b/c there is no hurry to get this into a new package.

Closes #528 