### PR TITLE
[DO NOT MERGE] ENH opt-out for checking solvability

### DIFF
--- a/recipe/migrations/pypy.yaml
+++ b/recipe/migrations/pypy.yaml
@@ -11,6 +11,8 @@ __migrator:
   migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
     1
   bump_number: 1   # Hashes changed for cpython, so it's better to bump build numbers.
+  # do not use mamba to check if the issued PRs are solvable
+  check_solvable: false
 
 python:
   - 3.6.* *_cpython


### PR DESCRIPTION
This PR opts pypy out of solvability checks using mamba.

xref: https://github.com/regro/cf-scripts/pull/968

Do not merge until the PR on regro/cf-scripts above is done.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
