### PR TITLE
Remove libpcap max_pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -225,8 +225,6 @@ pin_run_as_build:
     max_pin: x.x
   libmatio:
     max_pin: x.x
-  libpcap:
-    max_pin: x.x
   libpng:
     max_pin: x.x
   librdkafka:


### PR DESCRIPTION
The same [max_pin](https://github.com/conda-forge/libpcap-feedstock/pull/8#discussion_r415108506) was added to the package itself in
conda-forge/libpcap-feedstock#8.

cc: @nehaljwani