### PR TITLE
ENH move to azure for ppc64le on R

### DIFF
--- a/recipe/migrations/r400.yaml
+++ b/recipe/migrations/r400.yaml
@@ -18,6 +18,10 @@ __migrator:
     1
   automerge: true
 
+  # use azure since things are failing on travis (2020/05/01)
+  conda_forge_yml_patches:
+    provider.linux_ppc64le: azure
+
 # The name of the feedstock you wish to migrate with dashes replaced by
 # underscores
 r_base:


### PR DESCRIPTION
This PR moves the R migration to patch in azure instead of travis on its PRs using the new syntax in https://github.com/regro/cf-scripts/pull/992.

cc @conda-forge/bot @conda-forge/r 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
