### PR TITLE
Pin alsa-lib to 1.1.5, the widely-used version.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -334,6 +334,8 @@ blas_impl:
 
 abseil_cpp:
   - '20200225.2'
+alsa_lib:
+  - 1.1.5
 arb:
   - 2.17
 arpack:


### PR DESCRIPTION
`alsa-lib` already has a run_exports with max_pin=x.x.x, and up until two days ago there was only the one version released on conda-forge. This will set the pin for that version with no required rebuilds. Then packages can update to the new version of `alsa-lib` with a migrator to follow.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
