### PR TITLE
Pin gnuradio-core to 3.8.1.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -376,6 +376,8 @@ gf2x:
   - 1.2
 gdk_pixbuf:
   - 2.36.12
+gnuradio_core:
+  - 3.8.1
 gsl:
   - 2.6
 gstreamer:


### PR DESCRIPTION
There are now a few packages that build against `gnuradio-core`'s C++ library:
- gnuradio-osmosdr
- gnuradio-soapy
- gqrx

with many more possible/likely. It would be good to have a pin so that they can stay in sync and update together. `gnuradio-core` already has a `run_exports` with `max_pin=x.x.x`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
