### PR TITLE
Pin soapysdr to 0.7.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -591,6 +591,8 @@ singular:
   - 4.1.2
 snappy:
   - 1
+soapysdr:
+  - 0.7
 sox:
   - 14.4.2
 sqlite:


### PR DESCRIPTION
There are now a few packages that build against `soapysdr`'s C++ library:
- gnuradio-osmosdr
- gnuradio-soapy
- soapysdr-module-plutosdr
- soapysdr-module-uhd

with many more possible/likely. It would be good to have a pin so that they can stay in sync and update together. `soapysdr` already has a `run_exports` with `max_pin=x.x`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
