### PR TITLE
Pin uhd to 3.15.0.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -602,6 +602,8 @@ tk:
   - 8.6                # [not ppc64le]
 tiledb:
   - 1.7
+uhd:
+  - 3.15.0
 vc:                    # [win]
   - 14                 # [win]
 vlfeat:


### PR DESCRIPTION
There are now a few packages that build against `uhd`'s C/C++ library:
- gnuradio-osmosdr
- gnuradio-uhd (gnuradio parent package)
- soapysdr-module-uhd

I'm not aware of any more packages that might depend on `uhd` in the future, but it would still be nice to have a pin so that keeping these in sync is easier. `uhd` already has a `run_exports` with
`max_pin=x.x.x`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
