### PR TITLE
Add windows compatible jasper pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -423,7 +423,9 @@ icu:
 isl:
   - 0.19
 jasper:
-  - 1.900.1
+  # the first windows build of jasper was 2.0.14
+  - 1.900.1  # [not win]
+  - 2.0.14   # [win]
 jpeg:
   - 9
 libjpeg_turbo:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -424,8 +424,8 @@ isl:
   - 0.19
 jasper:
   # the first windows build of jasper was 2.0.14
-  - 1.900.1  # [not win]
-  - 2.0.14   # [win]
+  - 1  # [not win]
+  - 2  # [win]
 jpeg:
   - 9
 libjpeg_turbo:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

OpenCV currently builds with Jasper, and this is the first jasper build for windows on conda-forge.
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
