### PR TITLE
Add `treelite` to arch rebuild

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -204,3 +204,4 @@ statsmodels
 imagecodecs
 tomopy
 scikit-build
+treelite


### PR DESCRIPTION
Includes `treelite` as part of the `aarch64`/`ppc64le` rebuild.

cc @conda-forge/treelite

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
