### PR TITLE
Arch-migrate micromamba

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -205,3 +205,4 @@ imagecodecs
 tomopy
 scikit-build
 treelite
+micromamba


### PR DESCRIPTION
This adds a build of micromamba to the arch migrator. 

Would be cool to make this usable on Raspberry Pi's etc.!