### PR TITLE
Unify numpy pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -525,8 +525,7 @@ ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  - 1.14       # [not (aarch64 or ppc64le)]
-  - 1.16       # [aarch64 or ppc64le]
+  - 1.16
 occt:
   - 7.4
 openblas:

--- a/recipe/migrations/pypy.yaml
+++ b/recipe/migrations/pypy.yaml
@@ -21,12 +21,9 @@ python:
   - 3.6.* *_73_pypy   # [not win64]
 
 numpy:
-  - 1.14       # [not (aarch64 or ppc64le)]
-  - 1.14       # [not (aarch64 or ppc64le)]
-  - 1.14       # [not (aarch64 or ppc64le)]
-  - 1.16       # [aarch64 or ppc64le]
-  - 1.16       # [aarch64 or ppc64le]
-  - 1.16       # [aarch64 or ppc64le]
+  - 1.16
+  - 1.16
+  - 1.16
   - 1.18       # [not win64]
 
 python_impl:


### PR DESCRIPTION
This makes maintenance of a lot of packages easier, also quite some packages already use 1.16 as the minimal version.

This probably qualifies for a announcement in the news?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
