### PR TITLE
add argon2-cffi to arch rebuild

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -214,3 +214,4 @@ cctools
 howardhinnant_date
 spdlog
 py-spy
+argon2-cffi


### PR DESCRIPTION
argon2-cffi is a new dependency of notebook.