### PR TITLE
bump NSPR and nss minor version for aarch64 and ppc64le

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -523,10 +523,14 @@ netcdf_fortran:
   - 4.5
 nettle:
   - 3.4
+# nss: aarch64 and ppc64le do not have builds for versions prior to 3.47
 nss:
-  - 3
+  - 3.39   # [not (aarch64 or ppc64le)]
+  - 3.47   # [aarch64 or ppc64le]
+# nspr: aarch64 and ppc64le do not have builds for versions prior to 4.24
 nspr:
-  - 4
+  - 4.20   # [not (aarch64 or ppc64le)]
+  - 4.24   # [aarch64 or ppc64le]
 nlopt:
   - 2.6.*
 ntl:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -523,14 +523,10 @@ netcdf_fortran:
   - 4.5
 nettle:
   - 3.4
-# nss: aarch64 and ppc64le do not have builds for versions prior to 3.47
 nss:
-  - 3.39   # [not (aarch64 or ppc64le)]
-  - 3.47   # [aarch64 or ppc64le]
-# nspr: aarch64 and ppc64le do not have builds for versions prior to 4.24
+  - 3
 nspr:
-  - 4.20   # [not (aarch64 or ppc64le)]
-  - 4.24   # [aarch64 or ppc64le]
+  - 4
 nlopt:
   - 2.6.*
 ntl:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -524,9 +524,9 @@ netcdf_fortran:
 nettle:
   - 3.4
 nss:
-  - 3.39
+  - 3
 nspr:
-  - 4.20
+  - 4
 nlopt:
   - 2.6.*
 ntl:


### PR DESCRIPTION
Is there a reason why NSPR is pinned to 4.20 at build time but 4.X at run-time?

Similarly for NSS

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
