### PR TITLE
Pin poco to 1.10.1 and migrate packages

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -567,6 +567,8 @@ slepc4py:
   - 3.12
 pixman:
   - 0.38
+poco:
+  - 1.10.1
 poppler:
   - 0.67.0
 proj:

--- a/recipe/migrations/poco1101.yaml
+++ b/recipe/migrations/poco1101.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1599488137
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+poco:
+  - 1.10.1


### PR DESCRIPTION
`poco` was yet unpinned, added a matching `run_exports` in https://github.com/conda-forge/poco-feedstock/commit/eba5b76d7d4ff99f5a848958f7e6332bc8d86d0f

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
