### PR TITLE
Add CUDA 11.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -55,6 +55,7 @@ cuda_compiler_version:
   - 10.0                       # [linux64]
   - 10.1                       # [linux64]
   - 10.2                       # [linux64]
+  - 11.0                       # [linux64]
 
 _libgcc_mutex:
   - 0.1 conda_forge
@@ -131,6 +132,7 @@ docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").
   - condaforge/linux-anvil-cuda:10.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
 
 zip_keys:
   -

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -55,7 +55,6 @@ cuda_compiler_version:
   - 10.0                       # [linux64]
   - 10.1                       # [linux64]
   - 10.2                       # [linux64]
-  - 11.0                       # [linux64]
 
 _libgcc_mutex:
   - 0.1 conda_forge
@@ -132,7 +131,6 @@ docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").
   - condaforge/linux-anvil-cuda:10.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
-  - condaforge/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
 
 zip_keys:
   -

--- a/recipe/migrations/cuda110.yaml
+++ b/recipe/migrations/cuda110.yaml
@@ -6,6 +6,8 @@ __migrator:
     1
   build_number:
     1
+  override_cbc_keys:
+    - cuda_compiler_stub
 
 cuda_compiler_version:         # [linux64]
   - None                       # [linux64]

--- a/recipe/migrations/cuda110.yaml
+++ b/recipe/migrations/cuda110.yaml
@@ -1,0 +1,28 @@
+migrator_ts: 1601612527
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+  - 11.0                       # [linux64]
+
+docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") or (os.environ.get("CONFIG_VERSION", "1") == "1" and linux)]
+  - condaforge/linux-anvil-comp7        # [os.environ.get("BUILD_PLATFORM") == "linux-64" or (os.environ.get("CONFIG_VERSION", "1") == "1" and linux64)]
+  - condaforge/linux-anvil-aarch64      # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" or (os.environ.get("CONFIG_VERSION", "1") == "1" and aarch64)]
+  - condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" or (os.environ.get("CONFIG_VERSION", "1") == "1" and ppc64le)]
+  - condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l" or (os.environ.get("CONFIG_VERSION", "1") == "1" and armv7l)]
+
+  - condaforge/linux-anvil-cuda:9.2     # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+   - condaforge/linux-anvil-cuda:10.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+   - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+   - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+   - condaforge/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]

--- a/recipe/migrations/cuda110.yaml
+++ b/recipe/migrations/cuda110.yaml
@@ -9,8 +9,8 @@ __migrator:
   override_cbc_keys:
     - cuda_compiler_stub
 
-cuda_compiler_version:         # [linux64]
-  - None                       # [linux64]
+cuda_compiler_version:
+  - None
   - 9.2                        # [linux64]
   - 10.0                       # [linux64]
   - 10.1                       # [linux64]

--- a/recipe/migrations/cuda110.yaml
+++ b/recipe/migrations/cuda110.yaml
@@ -22,7 +22,7 @@ docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").
   - condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l" or (os.environ.get("CONFIG_VERSION", "1") == "1" and armv7l)]
 
   - condaforge/linux-anvil-cuda:9.2     # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
-   - condaforge/linux-anvil-cuda:10.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
-   - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
-   - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
-   - condaforge/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:10.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]


### PR DESCRIPTION
Adds CUDA 11.0 to our build matrix.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The CUDA 11.0 Docker image was added in PR ( https://github.com/conda-forge/docker-images/pull/155 ).

Working on `nvcc` wrapper package changes in PR ( https://github.com/conda-forge/nvcc-feedstock/pull/43 ).