### PR TITLE
Finish icu=67 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -202,8 +202,6 @@ pin_run_as_build:
     max_pin: x
   hdf4:
     max_pin: x.x
-  icu:
-    max_pin: x
   isl:
     max_pin: x.x
   jasper:
@@ -435,7 +433,7 @@ hdf4:
 hdf5:
   - 1.10.5
 icu:
-  - 64.2
+  - 67
 isl:
   - '0.22'
 jasper:

--- a/recipe/migrations/icu67.yaml
+++ b/recipe/migrations/icu67.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '67'
-migrator_ts: 1588861771.6052268


### PR DESCRIPTION
`scilab` and `octave` are outstanding but both already haven't passed in other already closed migrations.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
