### PR TITLE
Revert "pause py39 pending abi meta pacakge"

### DIFF
--- a/recipe/migrations/python39.yaml
+++ b/recipe/migrations/python39.yaml
@@ -9,7 +9,6 @@ __migrator:
             - 3.7.* *_cpython
             - 3.8.* *_cpython
             - 3.6.* *_73_pypy
-    paused: true
 python:
   - 3.9.* *_cpython
 # additional entries to add for zip_keys


### PR DESCRIPTION
Reverts conda-forge/conda-forge-pinning-feedstock#842
For when we merge the abi package and we're ready to go.