### PR TITLE
Migrate to NCCL 2.7.8.1

### DIFF
--- a/recipe/migrations/nccl_2_7_8_1.yaml
+++ b/recipe/migrations/nccl_2_7_8_1.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+nccl:
+- 2.7.8.1
+migrator_ts: 1602122003


### PR DESCRIPTION
As `nccl` version `2.4.6.1` (current global version) lacks support for CUDA 11.0, we need to bump to a more recent version of `nccl` that does have CUDA 11.0 ( `2.7.3.1` or later would work https://github.com/NVIDIA/nccl/commit/5949d96f36d050e59d05872f8bbffd2549318e95 ). Here we just pick the latest version of `nccl`, which is `2.7.8.1`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
