### PR TITLE
Ensure that the python zip_keys is always present

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -546,7 +546,7 @@ ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  # part of t zip_keys with python
+  # part of a zip_keys: python, python_impl, numpy
   - 1.16   # [not (osx and arm64)]
   - 1.16   # [not (osx and arm64)]
   - 1.16
@@ -591,10 +591,12 @@ poppler:
 proj:
   - 7.1.0
 python:
+  # part of a zip_keys: python, python_impl, numpy
   - 3.6.* *_cpython    # [not (osx and arm64)]
   - 3.7.* *_cpython    # [not (osx and arm64)]
   - 3.8.* *_cpython
 python_impl:
+  # part of a zip_keys: python, python_impl, numpy
   - cpython   # [not (osx and arm64)]
   - cpython   # [not (osx and arm64)]
   - cpython

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -132,9 +132,11 @@ zip_keys:
   -                             # [unix]
     - c_compiler_version        # [unix]
     - cxx_compiler_version      # [unix]
-    - fortran_compiler_version  # [unix]  
+    - fortran_compiler_version  # [unix]
   -
     - python
+    - numpy
+    - python_impl
   -                             # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
     - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
     - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
@@ -544,6 +546,9 @@ ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
+  # part of t zip_keys with python
+  - 1.16   # [not (osx and arm64)]
+  - 1.16   # [not (osx and arm64)]
   - 1.16
 occt:
   - 7.4
@@ -590,6 +595,8 @@ python:
   - 3.7.* *_cpython    # [not (osx and arm64)]
   - 3.8.* *_cpython
 python_impl:
+  - cpython   # [not (osx and arm64)]
+  - cpython   # [not (osx and arm64)]
   - cpython
 qt:
   - 5.12


### PR DESCRIPTION
This was introduced by the pypy migration and other migrations now require
these zip_keys (python39)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
