### PR TITLE
Migrate glib to 2.64.6

### DIFF
--- a/recipe/migrations/glib2646.yaml
+++ b/recipe/migrations/glib2646.yaml
@@ -9,3 +9,5 @@ __migrator:
 
 glib:
   - 2.64.6
+libglib:
+  - 2.64.6

--- a/recipe/migrations/glib2646.yaml
+++ b/recipe/migrations/glib2646.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+glib:
+  - 2.64.6


### PR DESCRIPTION
This introduces the `libglib` package and will remove the `python` run dependency from a lot of packages, most notably `r-base`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
