### PR TITLE
ENH mark long-term migrations for updates to status page

### DIFF
--- a/recipe/migrations/boost_cpp1740.yaml
+++ b/recipe/migrations/boost_cpp1740.yaml
@@ -2,6 +2,7 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  longterm: True
 boost_cpp:
 - 1.74.0
 - 1.72.0   # [not (osx and arm64)]

--- a/recipe/migrations/gcc930.yaml
+++ b/recipe/migrations/gcc930.yaml
@@ -8,6 +8,7 @@ __migrator:
   override_cbc_keys:
     - fortran_compiler_stub
   paused: false
+  longterm: True
 
 c_compiler_version:            # [unix]
   - 11                         # [osx and arm64]

--- a/recipe/migrations/hdf51106.yaml
+++ b/recipe/migrations/hdf51106.yaml
@@ -2,6 +2,7 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  longterm: True
 hdf5:
 - 1.10.6
 migrator_ts: 1587001869.689825

--- a/recipe/migrations/pypy.yaml
+++ b/recipe/migrations/pypy.yaml
@@ -11,6 +11,7 @@ __migrator:
   bump_number: 1   # Hashes changed for cpython, so it's better to bump build numbers.
   # do not use mamba to check if the issued PRs are solvable
   check_solvable: false
+  longterm: True
 
 python:
   - 3.6.* *_cpython   # [not (osx and arm64)]

--- a/recipe/migrations/python39.yaml
+++ b/recipe/migrations/python39.yaml
@@ -11,6 +11,7 @@ __migrator:
             - 3.9.* *_cpython   # new entry
             - 3.6.* *_73_pypy
     paused: false
+    longterm: True
     pr_limit: 50
     exclude:
       # this shouldn't attempt to modify the python feedstocks


### PR DESCRIPTION
We are adding some metadata for migrations. The ones marked `longterm` here will appear in a different section of the status page for easier viewing and differentiation.

cc @conda-forge/bot @conda-forge/core 