### PR TITLE
add lcms2 and libraw to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -469,7 +469,7 @@ kealib:
 krb5:
   - 1.17.1
 lcms2:
-  - 2.11
+  - 2
 libarchive:
   - 3.3
 libblitz:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -468,6 +468,8 @@ kealib:
   - 1.4
 krb5:
   - 1.17.1
+lcms2:
+  - 2.11
 libarchive:
   - 3.3
 libblitz:
@@ -500,6 +502,8 @@ libprotobuf:
   - 3.12
 librdkafka:
   - 0.11.5
+libraw:
+  - 0.20
 librsvg:
   - 2
 libsecret:


### PR DESCRIPTION
I have noticed some compatibility problems with the latest pillow and the latest freeimage *_3 build that unvendors libraries and links to cf libs instead.

I have added the conflicting packages here, and I would hope that this would trigger a migration for freeimage. Am I correct with that assumption? :^)
