### PR TITLE
add migration to get global version pinning of libraw and lcms2

### DIFF
--- a/recipe/migrations/lcms2_libraw.yaml
+++ b/recipe/migrations/lcms2_libraw.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+lcms2:
+- '2'
+libraw:
+- '0.20'
+migrator_ts: 1605529287

--- a/recipe/migrations/libraw020.yaml
+++ b/recipe/migrations/libraw020.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-lcms2:
-- '2'
 libraw:
 - '0.20'
 migrator_ts: 1605529287


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I have noticed some compatibility problems with the latest `pillow` and the latest `freeimage` *_3 build that unvendors libraries and links to cf libs instead.

<!--
Please add any other relevant info below:
-->
