### PR TITLE
Create a migrator for openexr pinning

### DIFF
--- a/recipe/migrations/openexr_253.yaml
+++ b/recipe/migrations/openexr_253.yaml
@@ -8,4 +8,4 @@ __migrator:
     1
 
 openexr:
-  - 2.5.3
+  - 2.5

--- a/recipe/migrations/openexr_253.yaml
+++ b/recipe/migrations/openexr_253.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1605889720
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+openexr:
+  - 2.5.3


### PR DESCRIPTION
https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/665 added a pinning for openexr but since many older packages were built with 2.5.2 instead of 2.5.1, this is causing certain package builds to break.

Because 2.5.3 is available now, we might as well update the pinning to match that.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
