### PR TITLE
ENH add pin for log4cxx

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -520,6 +520,8 @@ libxml2:
   - 2.9
 libuuid:
   - 2.32.1
+log4cxx:
+  - 0.11.0
 lz4_c:
   - 1.9.2
 lzo:

--- a/recipe/migrations/log4cxx0110.yaml
+++ b/recipe/migrations/log4cxx0110.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1606050656
+__migrator:
+  kind:
+    version
+  migration_number: 1
+  build_number: 1
+
+log4cxx:
+  - 0.11.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This library changes the SONAME with every version bump, so it has a run export of `x.x.x`. Thus the pin is all the way down to the patch version. 
