### PR TITLE
Add sundials to arch-rebuild

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -298,3 +298,4 @@ xtensor-blas
 pyerfa
 libopus
 heaptrack
+sundials


### PR DESCRIPTION
[Cantera](https://cantera.org/) is an important dependency for us for work in a university research center (https://github.com/illinois-ceesd/). I am [readying a recipe](https://github.com/conda-forge/staged-recipes/pull/13414) for it. Importantly, we need Cantera built on Power9, and Sundials is the only dependency for which Power9 packages aren't yet available. In preparation for getting Cantera built there, I am requesting Sundials be built there also.