### PR TITLE
pin qtkeychain 0.12.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -289,6 +289,8 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
+  qtkeychain:
+    max_pin: x.x
   readline:
     max_pin: x
   r-base:
@@ -610,6 +612,8 @@ python_impl:
   - cpython
 qt:
   - 5.12
+qtkeychain:
+  - 0.12
 re2:
   - 2020.11.01
 readline:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -613,7 +613,7 @@ python_impl:
 qt:
   - 5.12
 qtkeychain:
-  - 0.12
+  - 0.11
 re2:
   - 2020.11.01
 readline:


### PR DESCRIPTION
We did not pin this before b/c [we did not need to](https://abi-laboratory.pro/index.php?view=timeline&l=qtkeychain). However, the latest version added a few changes that may be incompatible, see https://github.com/conda-forge/qtkeychain-feedstock/pull/11#issuecomment-747866848

Pinging @gillins.

PS: I guess we'll need a repo data patch too. I never get those right :-/