### PR TITLE
add clingo to osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -118,3 +118,4 @@ libdb
 bsddb3
 openmpi
 cvxpy
+clingo


### PR DESCRIPTION
Clingo seems to compile fine of ARM (homebrew is already working https://formulae.brew.sh/formula/clingo).
