### PR TITLE
Zip fortran with c/cxx compilers

### DIFF
--- a/recipe/migrations/cuda110.yaml
+++ b/recipe/migrations/cuda110.yaml
@@ -17,6 +17,10 @@ __migrator:
       - 9
       - 8
       - 7
+    fortran_compiler_version:
+      - 9
+      - 8
+      - 7
 
 cuda_compiler_version:
   - None
@@ -30,6 +34,9 @@ c_compiler_version:     # [linux]
   - 7                   # [linux64 or aarch64]
   - 8                   # [ppc64le]
 cxx_compiler_version:   # [linux]
+  - 7                   # [linux64 or aarch64]
+  - 8                   # [ppc64le]
+fortran_compiler_version:  # [linux]
   - 7                   # [linux64 or aarch64]
   - 8                   # [ppc64le]
 


### PR DESCRIPTION
Not sure if this is a proper fix...In https://github.com/conda-forge/openmpi-feedstock/pull/71 I saw that the C compiler could be resolved to 7 but Fortran compiler to 9, leading to conflicts. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
