### PR TITLE
Add open62541 to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -150,3 +150,4 @@ google-cloud-cpp
 pyodbc
 turodbc
 texlive-core
+open62541


### PR DESCRIPTION
I am following the indication of @wolfv on adding arm on mcOS support to an existing feedstock. I am first testing this with a small package without a lot of dependencies (https://github.com/conda-forge/open62541-feedstock), to understand how this machinery works.