### PR TITLE
Loosen libtiff pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -502,7 +502,7 @@ libssh2:
 libsvm:
   - 3.21
 libtiff:
-  - 4.1.0
+  - 4
 libunwind:
   - 1
 libv8:


### PR DESCRIPTION
`run_exports` is major only, so loosen the pin to allow for different versions https://github.com/conda-forge/libtiff-feedstock/blob/93146b2fc91af119c6649904661777fa739d3308/recipe/meta.yaml#L34-L35

This may unblock some unsolvable migrations.