### PR TITLE
End rocksdb613

### DIFF
--- a/recipe/migrations/rocksdb613.yaml
+++ b/recipe/migrations/rocksdb613.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1610812522.8105006
-rocksdb:
-- '6.13'


### PR DESCRIPTION
Manually end this as @conda-forge/go-cockroach is depending hard on `rocksdb=6.2` and won't build with this one.