### PR TITLE
Add migration to pin volk to 2.4

### DIFF
--- a/recipe/migrations/volk24.yaml
+++ b/recipe/migrations/volk24.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1611268269
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+volk:
+  - 2.4


### PR DESCRIPTION
`volk` already has a matching 'x.x' `run_exports`.

A recent version upgrade made me realize that having this pinned would be really nice for keeping at least builds of the following packages in sync:

- `gnuradio-core`
- `gnuradio-osmosdr`
- `gnuradio-satellites`

Did I do this right by including a migrator as well? All of the above have been rebuilt with `volk 2.4` already, but obviously not with the pin included.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
