### PR TITLE
End libprotobuf314

### DIFF
--- a/recipe/migrations/libprotobuf314.yaml
+++ b/recipe/migrations/libprotobuf314.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.14'
-migrator_ts: 1607035151.2279923


### PR DESCRIPTION
Ending this manually, outstanding are only @conda-forge/caffe and @conda-forge/shogun which both have a large number of other already closed migration PRs and would need some better level of maintenance love.