### PR TITLE
add bootstrapping variable to conda_build_config.yaml

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -161,6 +161,11 @@ BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
 cdt_arch: armv7l                          # [armv7l]
 BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
+# bootstrapping specifies whether or not a recipe is run in "bootstrapping"
+# mode during the initial progress of adding a new platform.  Most recipes
+# will not need this value.  Possible values are: "yes" and "no".
+bootstrapping: no
+
 # TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:
   arpack:


### PR DESCRIPTION
During the process of bootstrapping packages to a new architecture, it is sometimes necessary to build packages in bootstrapping mode.  For example, when the full functionality of the package isn't available yet, but the package is necessary to build other packages will make the full functionality available later (in a regular non-bootstrapping) build.

In order to decide whether or not a build is run in bootstrapping mode, I suggest adding a new variable to `conda_build_config.yaml` named `bootstrapping` whose value is either "yes" or "no".

In a recipe, we can then distinguish packages created by using:
```
build:
{% if bootstrapping == 'yes' %}
  number: 0
  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_bootstrapping
{% else %}
  number: 1
{% endif %}
```
For example, we can disable build requirements the following way:
```
requirements:
  build:
{% if bootstrapping != 'yes' %}
    - libtool  # [unix]
    - bash     # [unix]
{% endif %}
```
In some cases it may the necessary to have access to the bootstrapping variable from within `build.sh`:
```
  script_env:
    - BOOTSTRAPPING={{ bootstrapping }}
```
