### PR TITLE
Update perl pin for osx-arm64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -579,7 +579,8 @@ pango:
 pari:
   - 2.11
 perl:
-  - 5.26.2
+  - 5.26.2  # [not (osx and arm64)]
+  - 5.32.0  # [osx and arm64]
 petsc:
   - '3.13'
 petsc4py:


### PR DESCRIPTION
This PR updates the `perl` pin for `osx and arm64` to the only version available.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
