### PR TITLE
Update osx_arm64 - add pygeos

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -206,3 +206,4 @@ libnetcdf
 xerces-c
 libspatialindex
 rtree
+pygeos


### PR DESCRIPTION
Now GEOS has builds for OSX ARM, can add pygeos as well (Shapely has already been added)