### PR TITLE
Fix CUDA 11.1/11.2 migrator 

### DIFF
--- a/recipe/migrations/cuda111_112.yaml
+++ b/recipe/migrations/cuda111_112.yaml
@@ -29,6 +29,11 @@ __migrator:
       - quay.io/condaforge/linux-anvil-cuda:11.0    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.1    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.2    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+
+      - quay.io/condaforge/linux-anvil-cos7-cuda:9.2     # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cos7-cuda:10.0    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cos7-cuda:10.1    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cos7-cuda:10.2    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
     cuda_compiler_version:
       - None
       - 9.2
@@ -39,10 +44,18 @@ __migrator:
       - 11.1
       - 11.2
 
+      - 9.2
+      - 10.0
+      - 10.1
+      - 10.2
+
 cuda_compiler:                 # [linux64 or win]
   - nvcc                       # [linux64 or win]
 cuda_compiler_version:
   - None
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64 or win]
+  - 10.1                       # [linux64 or win]
   - 10.2                       # [linux64 or win]
   - 11.0                       # [linux64 or win]
   - 11.1                       # [linux64 or win]
@@ -57,6 +70,9 @@ cxx_compiler_version:   # [linux]
 
 cudnn:
   - undefined
+  - 7                   # [linux64]
+  - 7                   # [linux64 or win]
+  - 7                   # [linux64 or win]
   - 7                   # [linux64 or win]
   - 8                   # [linux64 or win]
   - 8                   # [linux64 or win]
@@ -69,6 +85,9 @@ cdt_name:  # [linux]
   - cos7   # [linux and armv7l]
 
   - cos6   # [linux64]
+  - cos6   # [linux64]
+  - cos6   # [linux64]
+  - cos6   # [linux64]
   - cos7   # [linux64]
   - cos7   # [linux64]
   - cos7   # [linux64]
@@ -79,6 +98,9 @@ docker_image:                                   # [os.environ.get("BUILD_PLATFOR
   - quay.io/condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
   - quay.io/condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
 
+  - quay.io/condaforge/linux-anvil-cuda:9.2     # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-cuda:10.0    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-cuda:10.1    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-cuda:10.2    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-cuda:11.0    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-cuda:11.1    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Looks like regardless of the decision to drop CUDA 9.2/10.0/10.1, the migrator has to be a superset to cover all supported versions. Locally tested with the cuDNN and cuTENSOR feedstocks, which the bot is currently unable to migrate. No new yaml is added after rerendering.

(btw idk why the rerender command has to have the `-e` flag, like `conda smithy rerender -e recipe/conda_build_config.yaml`, otherwise I still get errors...)  

cc: @jaimergp @beckermr @isuruf @jakirkham @conda-forge/core 