### PR TITLE
Pin rust to <1.49 on osx-64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -84,7 +84,7 @@ rust_compiler:
   - rust
 # Pin rust to <1.49 on osx-64 due to min deployment target req, cf. https://github.com/conda-forge/rust-feedstock/issues/73
 rust_compiler_version:  # [osx and x86_64]
-  - 1.48                # [osx and x86_64]
+  - 1.46                # [osx and x86_64]
 
 macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
@@ -620,7 +620,7 @@ ruby:
   - 2.6
 # Pin rust to <1.49 on osx-64 due to min deployment target req, cf. https://github.com/conda-forge/rust-feedstock/issues/73
 rust:     # [osx and x86_64]
-  - 1.48  # [osx and x86_64]
+  - 1.46  # [osx and x86_64]
 r_base:
   - 3.6  # [not (osx and arm64)]
   - 4.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -615,6 +615,9 @@ root_base:
 ruby:
   - 2.5
   - 2.6
+# Pin rust to <1.49 on osx-64 due to min deployment target req, cf. https://github.com/conda-forge/rust-feedstock/issues/73
+rust:     # [osx and x86_64]
+  - 1.48  # [osx and x86_64]
 r_base:
   - 3.6  # [not (osx and arm64)]
   - 4.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -82,6 +82,9 @@ target_gobin:
 # Rust Compiler Options
 rust_compiler:
   - rust
+# Pin rust to <1.49 on osx-64 due to min deployment target req, cf. https://github.com/conda-forge/rust-feedstock/issues/73
+rust_compiler_version:  # [osx and x86_64]
+  - 1.48                # [osx and x86_64]
 
 macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]


### PR DESCRIPTION
due to min deployment target req,
cf. https://github.com/conda-forge/rust-feedstock/issues/73

cc @conda-forge/rust, @isuruf