### PR TITLE
Marked suitesparse and arpack for osx64_arm migration.

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -324,3 +324,5 @@ jaeger
 anyio
 pre-commit
 lightgbm
+suitesparse
+arpack

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -220,4 +220,5 @@ rosdistro
 apr
 log4cxx
 py-cpuinfo
-
+suitesparse
+arpack


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This PR adds the `suitesparse` and `arpack` libraries to the list of packages to make them available under `osx_arm64`.