### PR TITLE
build nodejs packages for 12, 14, 15

### DIFF
--- a/recipe/migrations/nodejs15.yaml
+++ b/recipe/migrations/nodejs15.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1614244658
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+nodejs:
+  - 15
+  - 14
+  - 12


### PR DESCRIPTION
In general, I think it's good target to support one or two LTS releases (always even numbered), and at most one non-LTS (always odd numbered). [nodejs release page](https://nodejs.org/en/about/releases/).

To me, that would mean dropping builds for node 15 and 12 when node 16 is released this spring.

My goal is for this to allow us to prompt global rebuilds of nodejs packages when there are new nodejs releases. I don't know if that will happen on the first addition since this pinning isn't present yet.
