### PR TITLE
Pin tbb to 2020

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -641,6 +641,8 @@ sqlite:
 suitesparse:
   - 5.6                # [not win]
   - 5.4                # [win]
+tbb:
+  - 2020
 tk:
   - 8.6                # [not ppc64le]
 tiledb:


### PR DESCRIPTION
This PR is created to address 1b from https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/1227#issuecomment-781493615. Not sure about correctness of pinning to major version, currently the latest available in conda-forge is TBB 2020.2, but the latest released is TBB 2020.3. So in theory TBB 2020.3 may become available in conda-forge, but later than oneTBB 2021.1.1.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
