### PR TITLE
End libprotobuf 3.15 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -481,7 +481,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - '3.14'
+  - '3.15'
 librdkafka:
   - '1.4'
 librsvg:

--- a/recipe/migrations/libprotobuf315.yaml
+++ b/recipe/migrations/libprotobuf315.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.15'
-migrator_ts: 1613798277.3441222


### PR DESCRIPTION
Everything except @conda-forge/caffe and @conda-forge/go-cockroach has been migrated but these two are not actively maintained and were already skipped in the last `libprotobuf` migration.