### PR TITLE
Migrate NCCL to 2.8.4.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -529,7 +529,7 @@ mumps_mpi:
 mumps_seq:
   - 5.2
 nccl:
-  - 2.7.8.1
+  - 2.8.4.1
 ncurses:
   - 6.2
 netcdf_cxx4:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -529,7 +529,7 @@ mumps_mpi:
 mumps_seq:
   - 5.2
 nccl:
-  - 2.8.4.1
+  - 2.7.8.1
 ncurses:
   - 6.2
 netcdf_cxx4:

--- a/recipe/migrations/nccl_2_8_4_1.yaml
+++ b/recipe/migrations/nccl_2_8_4_1.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  kind: version
+  migration_number: 1
+  build_number: 1
+nccl:
+  - 2.8.4.1
+migrator_ts: 1614284969


### PR DESCRIPTION
This is to fix the migration error in CuPy, see https://gitter.im/conda-forge/conda-forge.github.io?at=6037ccaecdbfc0620c2a5559.

cc: @jakirkham @kkraus14 @conda-forge/core


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
