### PR TITLE
add migrator for zeromq to 4.3.4

### DIFF
--- a/recipe/migrations/zeromq-434.yaml
+++ b/recipe/migrations/zeromq-434.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1614338156
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+zeromq:
+  - 4.3.4


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

add a migrator to zeromq 4.3.4. As dicussed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/941, a migrator is needed because zeromq has different version pins for windows/unix