### PR TITLE
Pin and migrate libgit2 to 1.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -466,6 +466,8 @@ libffi:
   - '3.3'
 libgdal:
   - '3.1'
+libgit2:
+  - '1.1'
 libiconv:
   - 1.16
 libkml:

--- a/recipe/migrations/libgit2_11.yaml
+++ b/recipe/migrations/libgit2_11.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1614596885
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+libgit2:
+  - '1.1'
+


### PR DESCRIPTION
This isn't pinned yet and changes SONAME on minor releases. Thus migrate according to the `run_exports`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
