### PR TITLE
Migrate and pin pcre(2)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -585,6 +585,10 @@ slepc:
   - '3.13'
 slepc4py:
   - '3.13'
+pcre:
+  - '8'
+pcre2:
+  - '10.36'
 pixman:
   - 0
 poco:

--- a/recipe/migrations/pcre2_1036.yaml
+++ b/recipe/migrations/pcre2_1036.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1614603878
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+pcre2:
+  - '10.36'
+

--- a/recipe/migrations/pcre8.yaml
+++ b/recipe/migrations/pcre8.yaml
@@ -1,0 +1,13 @@
+migrator_ts: 1614603877
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+pcre:
+  - '8'
+
+


### PR DESCRIPTION
I have some conflicts as there is no global pin for `pcre2` but as I did neither find `pcre` in the pinnings, I've added a migration for it, too.