### PR TITLE
Add migrator to pin libiio to 0.21 (current version).

### DIFF
--- a/recipe/migrations/libiio021.yaml
+++ b/recipe/migrations/libiio021.yaml
@@ -1,0 +1,11 @@
+migrator_ts: 1614895224
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+
+libiio:
+  - 0.21


### PR DESCRIPTION
At least the following packages depend on libiio (run_exports 'x.x'):
libad9361
libm2k
soapysdr-module-plutosdr

and they currently cannot be installed together because not all have
been rebuilt for libiio 0.21. The pin will obviously make this easier to
keep in sync in the future.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
