### PR TITLE
End arrow_cpp300 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -340,7 +340,7 @@ arb:
 arpack:
   - 3.7
 arrow_cpp:
-  - 2.0.0
+  - 3.0.0
 aws_c_common:
   - 0.5.1
 aws_c_event_stream:

--- a/recipe/migrations/arrow_cpp300.yaml
+++ b/recipe/migrations/arrow_cpp300.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-arrow_cpp:
-- 3.0.0
-migrator_ts: 1611693759.592137


### PR DESCRIPTION
Everything except @conda-forge/perspective has been merged. This is though waiting on https://github.com/conda-forge/perspective-feedstock/pull/18 which will take a bit longer and will also remove the `arrow-cpp` pin from the recipe.