### PR TITLE
End json_c015 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -443,7 +443,7 @@ jpeg:
 libjpeg_turbo:
   - 2
 json_c:
-  - 0.13
+  - 0.15
 jsoncpp:
   - 1.9.4
 kealib:

--- a/recipe/migrations/json_c015.yaml
+++ b/recipe/migrations/json_c015.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-json_c:
-- '0.15'
-migrator_ts: 1613417703.130417


### PR DESCRIPTION
Both @conda-forge/shogun and @conda-forge/postgis are behind in several migrations and the former hasn't seen any activity lately.