### PR TITLE
NEP-29: Bump to oldest supported numpy (1.17)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -551,9 +551,9 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.16   # [not (osx and arm64)]
-  - 1.16   # [not (osx and arm64)]
-  - 1.16   # [not (osx and arm64)]
+  - 1.17   # [not (osx and arm64)]
+  - 1.17   # [not (osx and arm64)]
+  - 1.17   # [not (osx and arm64)]
   - 1.19   # [osx and arm64]
 occt:
   - 7.4

--- a/recipe/migrations/pypy.yaml
+++ b/recipe/migrations/pypy.yaml
@@ -22,9 +22,9 @@ python:
   - 3.6.* *_73_pypy   # [not (win64 or (osx and arm64))]
 
 numpy:
-  - 1.16       # [not (osx and arm64)]
-  - 1.16       # [not (osx and arm64)]
-  - 1.16
+  - 1.17       # [not (osx and arm64)]
+  - 1.17       # [not (osx and arm64)]
+  - 1.17
   - 1.18       # [not (win64 or (osx and arm64))]
 
 python_impl:


### PR DESCRIPTION
See https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table

All existing builds are compatible, no need for a migrator.