### PR TITLE
Added jax to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -275,3 +275,4 @@ pytest-asyncio
 colorlog
 nasm
 bazel
+jax


### PR DESCRIPTION
Added Google's JAX to osx_arm64.txt. It is a very important and used dependency (e.g. NumPyro depends on it)