### PR TITLE
Add migration for ROOT 6.22.6

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -620,7 +620,7 @@ readline:
 rocksdb:
   - "6.10"
 root_base:
-  - '6.22'
+  - '6.22.2'
 ruby:
   - 2.5
   - 2.6

--- a/recipe/migrations/root6226.yaml
+++ b/recipe/migrations/root6226.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1616102026
+root_base:
+- 6.22.6


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
ROOT had an ABI break in 6.22.6, so the attempt to pin to only minor versions failed. I'm patching the repodata in: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/129

Leaving as draft until I rebuild 6.22.6 with the correct run_exports.