### PR TITLE
add faiss feedstock for osx-arm migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -283,3 +283,4 @@ ijar
 grpc_java_plugin
 cantera
 albumentations
+faiss-split


### PR DESCRIPTION
For https://github.com/conda-forge/faiss-split-feedstock/issues/38.

It's not clear to me from https://conda-forge.org/docs/maintainer/knowledge_base.html#apple-silicon-builds whether I need to add the name of the feedstock or of the package, but I'm guessing the former.
