### PR TITLE
Update osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -313,3 +313,4 @@ orocos-kdl
 ogre
 pygit2
 tesseract
+coremltools


### PR DESCRIPTION
Support for coremltools on Mac M1 Silicon Needed. Please see issue #1414 

Direct support needed for coremltools WITHOUT the need to reinstall or rebuild numpy or scipy. Or the need to rebuild opencv, which again is working correctly with no need to rebuild. All suggestions on installing fail using suggestions outlined here:
apple/coremltools#1156
AGAIN -- Everything I need for my work is currently and correctly loaded into my working environment with the exception of coremltools.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
