### PR TITLE
update pin for libwebp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -501,9 +501,9 @@ libunwind:
 libv8:
   - 8.9.83
 libwebp:
-  - 1.1
+  - 1.2
 libwebp_base:
-  - 1.1
+  - 1.2
 libxml2:
   - 2.9
 libuuid:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -501,9 +501,9 @@ libunwind:
 libv8:
   - 8.9.83
 libwebp:
-  - 1.2
+  - 1
 libwebp_base:
-  - 1.2
+  - 1
 libxml2:
   - 2.9
 libuuid:


### PR DESCRIPTION
This moves the pin for libwebp from 1.1 to 1.2

Abi laboratory indicates 100% compatibility between 1.1 -> 1.2

As far as I understand this will also need a repodata patch to relax the pin to match everything from >=1.1,<1.3 , correct?

<img width="1127" alt="Screenshot 2021-04-10 at 13 17 58" src="https://user-images.githubusercontent.com/885054/114268004-2f0ca480-99ff-11eb-99d8-39fffb99f53d.png">
