### PR TITLE
Add CSPICE to osx_arm64 migrations

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -314,3 +314,4 @@ ogre
 pygit2
 tesseract
 coremltools
+cspice


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This pr adds the CSPICE C library to osx_arm64 migrations.

So far I have tried to follow the manual steps to add arm64 builds to cspice seen here but I still have failing builds at the moment: https://github.com/conda-forge/cspice-feedstock/pull/24 

The bigger annoyance at the moment is that the compiler flag "-m64" doesn't seem to be supported by the cross-compiler, I have some fixes pending in build.sh that remove the use of that flag but I don't know if that is safe to do...

*edit:* okay I now see the "-m64" flag issue was not related to osx_arm64 at all and just the linux arm side of things. I think I now have that side working, so once all tests pass the https://github.com/conda-forge/cspice-feedstock/pull/24  can be merged 

