### PR TITLE
Pin and migrate aws-c-io

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -339,6 +339,8 @@ aws_c_common:
   - 0.5.11
 aws_c_event_stream:
   - 0.2.7
+aws_c_io:
+  - 0.9.12
 aws_checksums:
   - 0.1.11
 aws_sdk_cpp:

--- a/recipe/migrations/awscio0912.yaml
+++ b/recipe/migrations/awscio0912.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1620804002
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  bump_number:
+    1
+aws_c_io:
+  - 0.9.12


### PR DESCRIPTION
We are using this in multiple feedstocks which are out of sync. As with every AWS C package, the ABI doesn't seem stable.