### PR TITLE
End abseil_cpp202103241 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -326,7 +326,7 @@ blas_impl:
   - blis         # [x86 or x86_64]
 
 abseil_cpp:
-  - '20210324.0'
+  - '20210324.1'
 alsa_lib:
   - 1.2.3
 arb:

--- a/recipe/migrations/abseil_cpp202103241.yaml
+++ b/recipe/migrations/abseil_cpp202103241.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-abseil_cpp:
-- '20210324.1'
-migrator_ts: 1619014814.6806118


### PR DESCRIPTION
Only @conda-forge/obake is open but this already was skipped in the previous migration. No need to keep this longer open.