### PR TITLE
Add migration for R 4.1

### DIFF
--- a/recipe/migrations/r410.yaml
+++ b/recipe/migrations/r410.yaml
@@ -1,0 +1,16 @@
+migrator_ts: 1621536224
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  automerge: true
+
+  # slow start, increase to 20/50 later
+  pr_limit: 2
+
+r_base:
+  - 4.0
+  - 4.1

--- a/recipe/migrations/r410.yaml
+++ b/recipe/migrations/r410.yaml
@@ -7,6 +7,7 @@ __migrator:
   build_number:
     0
   automerge: true
+  longterm: true
 
   # slow start, increase to 20/50 later
   pr_limit: 2

--- a/recipe/migrations/r410.yaml
+++ b/recipe/migrations/r410.yaml
@@ -5,7 +5,7 @@ __migrator:
   migration_number:
     1
   build_number:
-    1
+    0
   automerge: true
 
   # slow start, increase to 20/50 later

--- a/recipe/migrations/r410.yaml
+++ b/recipe/migrations/r410.yaml
@@ -4,8 +4,7 @@ __migrator:
     version
   migration_number:
     1
-  build_number:
-    0
+  bump_number: 0
   automerge: true
   longterm: true
 


### PR DESCRIPTION
FYI @conda-forge/r @conda-forge/r-base @conda-forge/core 

I would start this tomorrow morning CEST and would babysit it during the day to see if there are any blockers and likely increase the PR rate during the day.

Note that https://github.com/conda-forge/r-base-feedstock/pull/173 is still open but expected to be merged soon. 