### PR TITLE
Add Petsc, petsc4py to osx-arm64 migration list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -370,17 +370,7 @@ xorg-libxrandr
 xorg-libxtst
 r-png
 scip
-libblas
-libcblas
-liblapack
-yaml
-hypre
-metis
-ptscotch
-superlu
-superlu_dist
 petsc
 petsc4py
 swig
-mumps-mpi
 hdf5

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -370,3 +370,17 @@ xorg-libxrandr
 xorg-libxtst
 r-png
 scip
+libblas
+libcblas
+liblapack
+yaml
+hypre
+metis
+ptscotch
+superlu
+superlu_dist
+petsc
+petsc4py
+swig
+mumps-mpi
+hdf5


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This adds Petsc and dependencies to the list of packages needing migration to osx-arm64. FYI @lmoresi @bmather