### PR TITLE
add pythran to osx_arm migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -393,3 +393,4 @@ detectron2
 nanoflann
 torchsparse
 clingo-dl
+pythran


### PR DESCRIPTION
Necessary for scipy 1.7.0, see https://github.com/conda-forge/scipy-feedstock/pull/169