### PR TITLE
Pin more aws-c-* libs

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -335,12 +335,22 @@ arpack:
   - 3.7
 arrow_cpp:
   - 4.0.1
+aws_c_auth:
+  - 0.6.0
+aws_c_cal:
+  - 0.5.10
 aws_c_common:
   - 0.5.11
 aws_c_event_stream:
   - 0.2.7
+aws_c_http:
+  - 0.6.4
 aws_c_io:
   - 0.9.14
+aws_c_mqtt:
+  - 0.7.6
+aws_c_s3:
+  - 0.1.19
 aws_checksums:
   - 0.1.11
 aws_sdk_cpp:


### PR DESCRIPTION
Currently they are all build in this pinning, thus we need no migration. But we expect to have more packages dependening on them except `aws-sdk-cpp` thus we need to pin them globally.

`awslabs` doesn't seem to care much about ABI stability, thus we pin this to the patch release, sadly.