### PR TITLE
End currently running aws-c-* migrations

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -340,13 +340,13 @@ aws_c_auth:
 aws_c_cal:
   - 0.5.10
 aws_c_common:
-  - 0.5.11
+  - 0.6.2
 aws_c_event_stream:
   - 0.2.7
 aws_c_http:
   - 0.6.4
 aws_c_io:
-  - 0.9.14
+  - 0.10.2
 aws_c_mqtt:
   - 0.7.6
 aws_c_s3:

--- a/recipe/migrations/aws_c_common062.yaml
+++ b/recipe/migrations/aws_c_common062.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_c_common:
-- 0.6.2
-migrator_ts: 1623326248.8694727

--- a/recipe/migrations/aws_c_io0101.yaml
+++ b/recipe/migrations/aws_c_io0101.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  automerge: true
-  migration_number: 1
-aws_c_io:
-- 0.10.1
-migrator_ts: 1622608956.1209087

--- a/recipe/migrations/aws_c_io0102.yaml
+++ b/recipe/migrations/aws_c_io0102.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_c_io:
-- 0.10.2
-migrator_ts: 1622784374.0701232


### PR DESCRIPTION
They are done once https://github.com/conda-forge/aws-crt-cpp-feedstock/pull/11 is merged.