### PR TITLE
Remove aws_sdk_cpp1939 migration

### DIFF
--- a/recipe/migrations/aws_sdk_cpp1939.yaml
+++ b/recipe/migrations/aws_sdk_cpp1939.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_sdk_cpp:
-- 1.9.39
-migrator_ts: 1624222878.112879


### PR DESCRIPTION
This doesn't work with the downstream packages, waiting for a working 1.9 release.