### PR TITLE
End grpc_cpp138 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -428,7 +428,7 @@ googleapis_cpp:
 graphviz:
   - 2.47
 grpc_cpp:
-  - '1.37'
+  - '1.38'
 harfbuzz:
   - 2
 hdf4:

--- a/recipe/migrations/grpc_cpp138.yaml
+++ b/recipe/migrations/grpc_cpp138.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-grpc_cpp:
-- '1.38'
-migrator_ts: 1621577848.0230918


### PR DESCRIPTION
Everything except @conda-forge/tensorflow has been migrated. That one is a difficult and longterm affair.