### PR TITLE
End libprotobuf316

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -490,7 +490,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - '3.15'
+  - '3.16'
 librdkafka:
   - '1.6'
 librsvg:

--- a/recipe/migrations/libprotobuf316.yaml
+++ b/recipe/migrations/libprotobuf316.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.16'
-migrator_ts: 1620379043.9019938


### PR DESCRIPTION
The outstanding ones are either unmaintained or packages of the more difficult sort (@conda-forge/tensorflow , @conda-forge/pytorch-cpu ) that only up migrations on new releases.