### PR TITLE
Close ipopt314 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -438,7 +438,7 @@ hdf5:
 icu:
   - 68
 ipopt:
-  - 3.13
+  - 3.14
 isl:
   - '0.22'
 jasper:

--- a/recipe/migrations/ipopt314.yaml
+++ b/recipe/migrations/ipopt314.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-ipopt:
-- 3.14
-migrator_ts: 1625331641


### PR DESCRIPTION
The only remaining not migrate port is ipyopt, but that package seems to be quite unmantained, see https://github.com/conda-forge/ipyopt-feedstock/pulls .