### PR TITLE
Add pin for opencv

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -487,6 +487,8 @@ libmicrohttpd:
   - 0.9
 libnetcdf:
   - 4.7.4
+libopencv:
+  - 4.5.2
 libpcap:
   - '1.10'
 libpng:


### PR DESCRIPTION
opencv is used a lot throughout conda-forge. At the moment it is not pinned though, although it has a run_export with the patch version. New versions can thus introduce incompatible downstream feedstocks. I propose to pin libopencv to avoid that. Note that opencv 4.5.3 was recently released, but has not yet landed in conda-forge. Thus it might very shortly lead to issues.