### PR TITLE
Close tinyxml2-9 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -678,7 +678,7 @@ tbb_devel:
 thrift_cpp:
   - 0.14.2
 tinyxml2:
-  - 8
+  - 9
 tk:
   - 8.6                # [not ppc64le]
 tiledb:

--- a/recipe/migrations/tinyxml2-9.yaml
+++ b/recipe/migrations/tinyxml2-9.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-tinyxml2:
-- 9
-migrator_ts: 1624484606


### PR DESCRIPTION
The only remaining packages (see https://conda-forge.org/status/#tinyxml2-9) are: 
* [`fast-rtps`](https://github.com/conda-forge/fast-rtps-feedstock) : archived, superseded by https://github.com/conda-forge/fast-dds-feedstock, see https://github.com/conda-forge/fast-rtps-feedstock/pull/13
* [`ros-pluginlib`](https://github.com/conda-forge/ros-pluginlib-feedstock): archive, superseded by RoboStack
* [`libmediainfo`](https://github.com/conda-forge/libmediainfo-feedstock): seems unmantained