### PR TITLE
Drop numpy 1.17

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -570,9 +570,9 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.17   # [not (osx and arm64)]
-  - 1.17   # [not (osx and arm64)]
-  - 1.17   # [not (osx and arm64)]
+  - 1.18   # [not (osx and arm64)]
+  - 1.18   # [not (osx and arm64)]
+  - 1.18   # [not (osx and arm64)]
   - 1.19   # [osx and arm64]
   - 1.19
 occt:


### PR DESCRIPTION

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

See https://numpy.org/neps/nep-0029-deprecation_policy.html

cc @conda-forge/core, @conda-forge/numpy 