### PR TITLE
Fix nodejs16 migration

### DIFF
--- a/recipe/migrations/nodejs16.yaml
+++ b/recipe/migrations/nodejs16.yaml
@@ -4,6 +4,6 @@ __migrator:
   migration_number: 1
 migrator_ts: 1626366230.4925187
 nodejs:
-- '12'
-- '14'
-- '16'
+ - 16
+ - 14
+ - 12


### PR DESCRIPTION
As seen in https://github.com/conda-forge/vsce-feedstock/pull/16 this fixes the migration. I'm unsure why though.