### PR TITLE
unpause win-pypy migration

### DIFF
--- a/recipe/migrations/pypy37-windows.yaml
+++ b/recipe/migrations/pypy37-windows.yaml
@@ -1,6 +1,6 @@
 migrator_ts: 1623865877
 __migrator:
-    paused: True
+    paused: False
     migration_number: 1
     operation: key_add
     primary_key: python


### PR DESCRIPTION
Follows #1668 & #1670, now that numpy has been built, see [here](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1668#issuecomment-884125276).

CC @isuruf @beckermr @mattip