### PR TITLE
add spdlog pinning and migration to 1.9.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -287,6 +287,8 @@ pin_run_as_build:
     min_pin: x.x
   sox:
     max_pin: x.x.x
+  spdlog:
+    max_pin: x.x
   sqlite:
     max_pin: x
   tk:
@@ -644,6 +646,8 @@ soapysdr:
   - 0.7
 sox:
   - 14.4.2
+spdlog:
+  - 1.8
 sqlite:
   - 3
 suitesparse:

--- a/recipe/migrations/spdlog190.yaml
+++ b/recipe/migrations/spdlog190.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+spdlog:
+- 1.9.0
+migrator_ts: 1626944267


### PR DESCRIPTION
We experienced some ABI incompatbility between spdlog 1.8.5 and 1.9. 

Therefore I am adding a global pin + a migrator. 