### PR TITLE
Fix aws-c-common pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -346,7 +346,7 @@ aws_c_auth:
 aws_c_cal:
   - 0.5.11
 aws_c_common:
-  - 0.6.7
+  - 0.6.8
 aws_c_event_stream:
   - 0.2.7
 aws_c_http:


### PR DESCRIPTION
The PRs for closing the migrations were merged in the wrong order.