### PR TITLE
adds pyreadstat and pyreadr to osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -492,3 +492,5 @@ pymde
 pyfftw
 gmatelastoplastic
 python-gmatelastoplastic
+pyreadstat
+pyreadr


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ yes] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [no ] Bumped the build number (if the version is unchanged)
* [ no] Reset the build number to `0` (if the version changed)
* [no ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [no ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I am trying to provide osx-arm64 builds for my packages [pyreadstat](https://github.com/conda-forge/pyreadstat-feedstock) and [pyreadr](https://github.com/conda-forge/pyreadr-feedstock) according to this: https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/. Hope this is the right procedure.

Will fix https://github.com/Roche/pyreadstat/issues/143