### PR TITLE
ENH skip pyqt for pypy37 on windows

### DIFF
--- a/recipe/migrations/pypy37-windows.yaml
+++ b/recipe/migrations/pypy37-windows.yaml
@@ -23,6 +23,8 @@ __migrator:
       - python
       - pypy3.6
       - pypy-meta
+      # we don't need pyqt for pypy and matplotlib
+      - pyqt
 
 python:                # [win]
   - 3.7.* *_73_pypy    # [win]


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/regro/cf-scripts/issues/1434 without hacking on the bot data. It will cause the bot to pluck pyqt from the graph for pypy37 on windows. 

cc @isuruf @CJ-Wright 