### PR TITLE
Remove nodejs 12 and 14 for osx arm64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -566,8 +566,8 @@ nettle:
   - '3.7'
 nodejs:
  - 16
- - 14
- - 12
+ - 14  # [not (osx and arm64)]
+ - 12  # [not (osx and arm64)]
 nss:
   - 3
 nspr:


### PR DESCRIPTION
Following the conversation [here](https://github.com/conda-forge/prettier-feedstock/pull/13#issuecomment-921582190) this removes the builds for nodejs 12 and 14 for osx arm64. I assume that bumping a build number is not required here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
