### PR TITLE
migrate to jasper 2

### DIFF
--- a/recipe/migrations/jasper2.yaml
+++ b/recipe/migrations/jasper2.yaml
@@ -1,0 +1,7 @@
+__migrator:
+￼  build_number: 1
+￼  kind: version
+￼  migration_number: 1
+￼jasper:
+￼- '2'
+￼migrator_ts: 1632848255.398075


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* Ensured the license file is being packaged.

@conda-forge-admin, please rerender

Attempting to resurrect #523 and get all packages depending on jasper to version 2

reference [API Laboratory](https://abi-laboratory.pro/index.php?view=timeline&l=jasper) which shows great stability for version 2 of the library.
