### PR TITLE
Fix jasper2 pinning typos

### DIFF
--- a/recipe/migrations/jasper2.yaml
+++ b/recipe/migrations/jasper2.yaml
@@ -2,6 +2,6 @@ __migrator:
 ￼  build_number: 1
 ￼  kind: version
 ￼  migration_number: 1
-￼jasper:
-￼- '2'
-￼migrator_ts: 1632848255.398075
+jasper:
+- '2'
+migrator_ts: 1632848255.398075


### PR DESCRIPTION
There seems to be some kind of hidden space:
![image](https://user-images.githubusercontent.com/90008/135141832-ec175fa0-3dec-40ec-9bd9-1f8d92f617a1.png)


<details>

```
INFO:conda_smithy.configure_feedstock:Downloading conda-forge-pinning-2021.09.28.17.32.49
INFO:conda_smithy.configure_feedstock:Extracting conda-forge-pinning to /tmp/tmp8jx3471a
Traceback (most recent call last):
  File "/home/mark/mambaforge/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/cli.py", line 666, in main
    args.subcommand_func(args)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/cli.py", line 471, in __call__
    self._call(args, tmpdir)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/cli.py", line 476, in _call
    configure_feedstock.main(
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/configure_feedstock.py", line 2084, in main
    set_migration_fns(forge_dir, config)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/configure_feedstock.py", line 1997, in set_migration_fns
    migrations_in_cfp = get_migrations_in_dir(cfp_migrations_dir)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/conda_smithy/configure_feedstock.py", line 1944, in get_migrations_in_dir
    yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/composer.py", line 64, in compose_node
    if self.check_event(AliasEvent):
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/parser.py", line 449, in parse_block_mapping_value
    if not self.check_token(KeyToken, ValueToken, BlockEndToken):
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/scanner.py", line 115, in check_token
    while self.need_more_tokens():
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/scanner.py", line 152, in need_more_tokens
    self.stale_possible_simple_keys()
  File "/home/mark/mambaforge/lib/python3.9/site-packages/yaml/scanner.py", line 291, in stale_possible_simple_keys
    raise ScannerError("while scanning a simple key", key.mark,
yaml.scanner.ScannerError: while scanning a simple key
  in "<unicode string>", line 6, column 1:
    ￼- '2'
    ^
could not find expected ':'
  in "<unicode string>", line 7, column 1:
    ￼migrator_ts: 1632848255.398075
    ^
````
</details>
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
