### PR TITLE
Update pin for gnuradio_core to 3.9.3

### DIFF
--- a/recipe/migrations/gnuradio_core393.yaml
+++ b/recipe/migrations/gnuradio_core393.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  bump_number: 1
+  kind: version
+  migration_number: 1
+gnuradio_core:
+  - 3.9.3
+migrator_ts: 1633442208


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #1372.

<!--
Please add any other relevant info below:
-->

All dependent packages are ready to update to the 3.9 series, and 3.9.3 is the latest release.
