### PR TITLE
Bump libopencv to 4.5.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -496,7 +496,7 @@ libmicrohttpd:
 libnetcdf:
   - 4.7.4
 libopencv:
-  - 4.5.2
+  - 4.5.3
 libpcap:
   - '1.10'
 libpng:


### PR DESCRIPTION
The recent migrations in the opencv feedstock (e.g. https://github.com/conda-forge/opencv-feedstock/pull/284 https://github.com/conda-forge/opencv-feedstock/pull/288 https://github.com/conda-forge/opencv-feedstock/pull/287) have landed only for version 4.5.3, while we still pin to 4.5.2 here. This leads to incompatibilities. This PR therefore bumps libopencv to 4.5.3.