### PR TITLE
Add `diffutils` to arch migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -438,3 +438,4 @@ nb_conda_kernels
 logzero
 numcodecs
 libvpx
+diffutils


### PR DESCRIPTION
This is needed in https://github.com/conda-forge/idyntree-feedstock/pull/8#issuecomment-947958749 .