### PR TITLE
Close out migration for perl5321

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -266,8 +266,6 @@ pin_run_as_build:
     max_pin: x.x
   pango:
     max_pin: x.x
-  perl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   qt:
@@ -607,8 +605,7 @@ pango:
 pari:
   - 2.13.* *_pthread
 perl:
-  - 5.26.2  # [not (osx and arm64)]
-  - 5.32.0  # [osx and arm64]
+  - 5.32.1
 petsc:
   - 3.14
 petsc4py:

--- a/recipe/migrations/perl5321.yaml
+++ b/recipe/migrations/perl5321.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1623045850.132499
-perl:
-- 5.32.1


### PR DESCRIPTION
Migration is done.
(There is one package with is "not solvable" which is outdated and the feedstock is now archived.)