### PR TITLE
add gym & kaggle to osx-arm

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -539,3 +539,5 @@ libvpx
 x265
 nds2-client-swig
 cartographer
+gym
+kaggle


### PR DESCRIPTION
Closing a gap for https://github.com/conda-forge/tensorflow-feedstock/issues/154.