### PR TITLE
Close out migration for spdlog190

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -279,8 +279,6 @@ pin_run_as_build:
     min_pin: x.x
   sox:
     max_pin: x.x.x
-  spdlog:
-    max_pin: x.x
   sqlite:
     max_pin: x
   tk:
@@ -671,7 +669,7 @@ soapysdr:
 sox:
   - 14.4.2
 spdlog:
-  - 1.8
+  - 1.9.0
 sqlite:
   - 3
 suitesparse:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -669,7 +669,7 @@ soapysdr:
 sox:
   - 14.4.2
 spdlog:
-  - 1.9.0
+  - 1.9
 sqlite:
   - 3
 suitesparse:

--- a/recipe/migrations/spdlog190.yaml
+++ b/recipe/migrations/spdlog190.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-spdlog:
-- 1.9.0
-migrator_ts: 1626944267


### PR DESCRIPTION
Migration is actually finished. The bot has `librmm` as "not solvable", but the migration for that has been done manually: https://github.com/conda-forge/librmm-feedstock/pull/13.