### PR TITLE
WIP Add r-tidyverse to migrations/osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -541,3 +541,4 @@ nds2-client-swig
 cartographer
 gym
 kaggle
+r-tidyverse


### PR DESCRIPTION
Enable `r-tidyverse` to build on osx-arm64 

Feedback welcome!

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering) **I will do this if needed!**
* [x] Ensured the license file is being packaged.


