### PR TITLE
add cross-python python_abi to ignored in python3.10

### DIFF
--- a/recipe/migrations/python310.yaml
+++ b/recipe/migrations/python310.yaml
@@ -20,6 +20,8 @@ __migrator:
       - python
       - pypy3.6
       - pypy-meta
+      - cross-python
+      - python_abi
 
 python:
   - 3.10.* *_cpython


### PR DESCRIPTION
cc @beckermr 