### PR TITLE
add sixs for multiarch

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -446,3 +446,4 @@ fonttools
 unicodedata2
 labelimg
 rectangle-packer
+sixs


### PR DESCRIPTION
add 'sixs' for drone.io builds, per https://conda-forge.org/docs/maintainer/infrastructure.html#drone-io

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hi team, I'm trying to add support for 'sixs' on aarch64, so adding it to arch_rebuild.txt per https://conda-forge.org/docs/maintainer/infrastructure.html#drone-io.