### PR TITLE
Migrate to vtk 9.1.0

### DIFF
--- a/recipe/migrations/vtk910.yaml
+++ b/recipe/migrations/vtk910.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1636491552.3933175
+vtk:
+- 9.1.0


### PR DESCRIPTION
VTK 9.1.0 was just merged in (https://github.com/conda-forge/vtk-feedstock/pull/221). This enables the HDF5 migration to run (https://github.com/conda-forge/vtk-feedstock/pull/222) which was previously not building for VTK 9.0.3 (https://github.com/conda-forge/vtk-feedstock/pull/218).

Hence I think we should migrate to vtk 9.1.0 to be in sync with other packages that have already migrated to the new version of HDF5.

Note that there is still a migration to vtk 9.0.3 running, but it is near complete.