### PR TITLE
Add missing gds_env libraries to osx_arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -562,3 +562,10 @@ pyspnego
 scikit-survival
 slycot
 mdtraj
+pyogrio
+gstools
+h3-py
+pyrosm
+quantecon
+rvlib
+python-levenshtein


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
While trying to work with the [gds_env](https://github.com/darribas/gds_env) on M1, I've noticed that some libraries need osx-arm64 versions. Adding all that caused issues.