### PR TITLE
Add restic to arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -573,3 +573,4 @@ python-levenshtein
 htcondor
 perl-unicode-linebreak
 ambertools
+restic


### PR DESCRIPTION
Enable restic on osx-arm64.  go compiler is available and is the only dependence.