### PR TITLE
Add occt migration to 7.6

### DIFF
--- a/recipe/migrations/occt76.yaml
+++ b/recipe/migrations/occt76.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1636942015.3933175
+occt:
+- 7.6


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I was trying to migtate smesh to vtk 9.0.3 (https://github.com/conda-forge/smesh-feedstock/pull/51). However, it fails because occt is pinned to 7.5. The migration to vtk 9.0.3 in occt has only landed in occt 7.6. Therefore I think we should migrate to occt 7.6.