### PR TITLE
End gsl27 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -408,7 +408,7 @@ gdk_pixbuf:
 gnuradio_core:
   - 3.9.4
 gsl:
-  - 2.6
+  - 2.7
 gsoap:
   - 2.8.117
 gstreamer:

--- a/recipe/migrations/gsl27.yaml
+++ b/recipe/migrations/gsl27.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  check_solvable: false
-gsl:
-- '2.7'
-migrator_ts: 1626373748.7306545


### PR DESCRIPTION
This PR ends the gsl27 migration, the only feedstock listed on the status page has been archived.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
