### PR TITLE
Add libzen, libmediainfo and pymediainfo to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -590,3 +590,6 @@ unicodedata2
 pyagrum
 cpp-terminal
 psygnal
+libzen
+libmediainfo
+pymediainfo


### PR DESCRIPTION
This PR adds 3 packages into the osx-arm64 migration.