### PR TITLE
Add spyder to aarch64 migrator

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -470,3 +470,4 @@ pulp
 cartopy
 htcondor
 elsi
+spyder


### PR DESCRIPTION
This should address
https://github.com/conda-forge/jellyfish-feedstock/pull/33
and
https://github.com/conda-forge/spyder-feedstock/pull/120
