### PR TITLE
Add VTK variants

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -737,7 +737,9 @@ vlfeat:
 volk:
   - '2.5'
 vtk:
-  - 9.0.1
+  - 9.1.0 qt*
+  - 9.1.0 egl*  # [linux64]
+  - 9.1.0 osmesa*  # [linux64]
 x264:
   - '1!161.*'
 xerces_c:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
In https://github.com/conda-forge/vtk-feedstock/pull/225 I added osmesa and egl variants of VTK.

I am not 100% this accomplishes what I want, but I would like to have packages that have `vtk` as a dependency and build variants themselves (https://github.com/conda-forge/occt-feedstock/pull/79/files) to automatically receive migration PRs.
