### PR TITLE
Skip migration to nodejs=14 on osx-arm64 (not available).

### DIFF
--- a/recipe/migrations/nodejs17.yaml
+++ b/recipe/migrations/nodejs17.yaml
@@ -6,4 +6,4 @@ migrator_ts: 1638024739.738037
 nodejs:
 - '17'
 - '16'
-- '14'
+- '14'  # [not (osx and arm64)]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The bot will currently try to generate nodejs=14 builds for osx-arm64, but nodejs=15 is the earliest version on conda-forge to support osx-arm64.  @isuruf said that adding a skip here was the proper way to keep the bot from doing this.

<!--
Please add any other relevant info below:
-->
