### PR TITLE
Add pinning for ccr and libhugetlbfs

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -387,6 +387,8 @@ bzip2:
   - 1
 cairo:
   - 1.16
+ccr:
+  - 1.3
 cfitsio:
   - 3.470
 coin_or_cbc:
@@ -521,6 +523,8 @@ libgdal:
   - '3.3'
 libgit2:
   - '1.3'
+libhugetlbfs:
+  - 2
 libiconv:
   - 1.16
 libkml:


### PR DESCRIPTION
No packages have been built with these two dependencies yet.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
