### PR TITLE
osx_arm64 migrations: libsigcpp, cairomm, graph-tool

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -654,3 +654,5 @@ socat
 r-irkernel
 coreutils
 libsigcpp
+cairomm
+graph-tool

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -653,3 +653,4 @@ r-cairo
 socat
 r-irkernel
 coreutils
+libsigcpp


### PR DESCRIPTION
These form a dependency chain:  `libsigcpp <- cairomm <- graph-tool`


xref conda-forge/libsigcpp-feedstock#23
xref conda-forge/graph-tool-feedstock#64

---

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
