### PR TITLE
osx_arm64 migration: Add galpy

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -656,3 +656,4 @@ coreutils
 libsigcpp
 cairomm
 graph-tool
+galpy


### PR DESCRIPTION
Adding the galpy package, compiles fine on an ARM64 machine.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
