### PR TITLE
Add C++ library libintervalxt

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -527,6 +527,8 @@ libhugetlbfs:
   - 2
 libiconv:
   - 1.16
+libintervalxt:
+  - 3
 libkml:
   - 1.3
 libiio:


### PR DESCRIPTION
libintervalxt uses semantic version. Current version is 3.2.0.

The feedstock is at https://github.com/conda-forge/intervalxt-feedstock.

Fixes https://github.com/conda-forge/intervalxt-feedstock/issues/2.