### PR TITLE
Add C++ library libexactreal

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -515,6 +515,8 @@ libeantic:
   - 1
 libevent:
   - 2.1.10
+libexactreal:
+  - 2
 libffi:
   - '3.3'
 libflint:


### PR DESCRIPTION
libexactreal uses semantic version. Current version is 2.2.1.

The feedstock is at https://github.com/conda-forge/exact-real-feedstock.

Fixes https://github.com/conda-forge/exact-real-feedstock/issues/5.