### PR TITLE
Add C++ library libflatsurf

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -517,6 +517,8 @@ libevent:
   - 2.1.10
 libffi:
   - '3.3'
+libflatsurf:
+  - 3
 libflint:
   - '2.8'
 libgdal:


### PR DESCRIPTION
libflatsurf uses semantic versioning. Current version is 3.9.3.

The feedstock is at https://github.com/conda-forge/flatsurf-feedstock.