### PR TITLE
add capnproto to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -385,6 +385,8 @@ bzip2:
   - 1
 cairo:
   - 1.16
+capnproto:
+  - 0.9.1
 ccr:
   - 1.3
 cfitsio:


### PR DESCRIPTION
Also adding run exports https://github.com/conda-forge/capnproto-feedstock/pull/25

According to soname changes in https://abi-laboratory.pro/index.php?view=timeline&l=capnproto