### PR TITLE
Add pin for assimp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -353,6 +353,8 @@ arrow_cpp:
   - 6.0.1
   - 5.0.0
   - 4.0.1
+assimp:
+  - 5.2
 aws_c_auth:
   - 0.6.10
 aws_c_cal:


### PR DESCRIPTION
`assimp` is used in many conda-forge packages, and has a `run_export` in it. To avoid incompatibilities in packages, it is convenient to add a pin for it in conda-forge-pinning.