### PR TITLE
add allennlp stack to osx-arm migrator

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -718,6 +718,11 @@ tesserocr
 climlab
 findutils
 xmlsec
+allennlp
+allennlp-models
+allennlp-optuna
+allennlp-semparse
+allennlp-server
 compas_view2
 compas_occ
 compas_cgal


### PR DESCRIPTION
It was [requested](https://github.com/allenai/allennlp/issues/5258#issuecomment-1014461862) on the upstream tracker, see also https://github.com/allenai/allennlp/issues/5558.