### PR TITLE
Add libdeflate to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -515,6 +515,8 @@ libcrc32c:
   - 1.1
 libdap4:
   - 3.20.6
+libdeflate:
+  - '1.10'
 libeantic:
   - 1
 libevent:


### PR DESCRIPTION
I had closed out the miration before ensure to add the pinning:
https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2519/files

I maintain the two packages that depend on this. They haven't had new builds since.
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
