### PR TITLE
Revert "Close out migration for abseil_cpp20211102"

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -340,7 +340,7 @@ blas_impl:
   - blis         # [x86 or x86_64]
 
 abseil_cpp:
- - '20211102.0'
+  - '20210324.2'
 alsa_lib:
   - 1.2.3
 antic:

--- a/recipe/migrations/abseil_cpp20211102.yaml
+++ b/recipe/migrations/abseil_cpp20211102.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1644918847
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+abseil_cpp:
+ - '20211102.0'


### PR DESCRIPTION
This reverts commit abdbc754d723721315629e52eef8bb310d2a05f3.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

cc @xhochy 

Sorry again for closing this one!
