### PR TITLE
Add pyright & macfsevents to osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -757,3 +757,5 @@ dagster
 libsass
 r-tidygraph
 numbalsoda
+pyright
+macfsevents


### PR DESCRIPTION
I checked that neither of these packages are on the list yet, and neither have closed PRs for this migration. Thanks!