### PR TITLE
Adding filprofiler to osx_arm migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -782,3 +782,4 @@ coolprop
 findent
 r-roxygen2
 ddtrace
+filprofiler


### PR DESCRIPTION
Hi, I'm trying to compile a osx_arm version for filprofiler (https://anaconda.org/conda-forge/filprofiler).

