### PR TITLE
Change `ucx` to `ucx-split` (feedstock name)

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -34,7 +34,7 @@ pytest-benchmark
 conda-forge-ci-setup
 oclgrind
 openmpi
-ucx
+ucx-split
 typing
 sqlalchemy
 root_pandas


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2656 ) in particular this feedback ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2656#discussion_r834969802 )

cc @isuruf

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
