### PR TITLE
Keep ffmpeg version 4.3 for windows

### DIFF
--- a/recipe/migrations/ffmpeg44.yaml
+++ b/recipe/migrations/ffmpeg44.yaml
@@ -3,5 +3,6 @@ __migrator:
   kind: version
   migration_number: 1
 ffmpeg:
-- '4.4'
+- '4.3'  # [win]
+- '4.4'  # [unix]
 migrator_ts: 1645963201.9878001


### PR DESCRIPTION
In the FFMPEG migration, we realized that we don't have packages for windows.

I made an attempt to build those from source, but I ran out of time.

I don't think it is worthwhile to hold up the migration for this. While we strive for feature parity, sometimes it is impossible with these performance orientated packages (pythorch, tensorflow, ffmpeg).

Hopefully this can be resolved soon, but I think for this keeping the windows pinning back is a useful compromise.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
