### PR TITLE
Create geotiff 1.7.1 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `conda-forge-pinning` can be installed with:
+Once the `conda-forge` channel has been enabled, `conda-forge-pinning` can be installed with `conda`:
 
 ```
 conda install conda-forge-pinning
 ```
 
-It is possible to list all of the versions of `conda-forge-pinning` available on your platform with:
+or with `mamba`:
+
+```
+mamba install conda-forge-pinning
+```
+
+It is possible to list all of the versions of `conda-forge-pinning` available on your platform with `conda`:
 
 ```
 conda search conda-forge-pinning --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search conda-forge-pinning --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search conda-forge-pinning --channel conda-forge
+
+# List packages depending on `conda-forge-pinning`:
+mamba repoquery whoneeds conda-forge-pinning --channel conda-forge
+
+# List dependencies of `conda-forge-pinning`:
+mamba repoquery depends conda-forge-pinning --channel conda-forge
 ```
 
 
@@ -66,10 +91,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -451,7 +451,7 @@ gdal:
 geos:
   - 3.10.2
 geotiff:
-  - '1.7.0'
+  - 1.7.0
 gfal2:
   - '2.20'
 gflags:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -204,8 +204,6 @@ pin_run_as_build:
     max_pin: x
   gdal:
     max_pin: x.x
-  geotiff:
-    max_pin: x.x.x
   glew:
     max_pin: x.x
   glpk:

--- a/recipe/migrations/geotiff171.yaml
+++ b/recipe/migrations/geotiff171.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1648658244.6519449
+geotiff:
+- 1.7.1


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* Ensured the license file is being packaged.

This PR:
1. Updates the pinned version of `geotiff` to use a version without single quotes, maybe this was causing grief before?
2. Creates a manual migration of `geotiff`, since I can not figure out why the bot has not created on.

closes #2654 