### PR TITLE
Revert "pause pypy38 for now"

### DIFF
--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -13,7 +13,7 @@ __migrator:
             - 3.7.* *_73_pypy
             - 3.8.* *_73_pypy
             - 3.9.* *_73_pypy
-    paused: True
+    paused: False
     longterm: True
     use_local: False
     check_solvable: True


### PR DESCRIPTION
Unpause pypy migration (stopped in #2668), now that problems have been resolved, as discussed in #2667.

I don't think we need to wait for the 7.3.9 (security) release, as it's binary compatible with the current 7.3.8.

CC @jakirkham @mattip @isuruf 