### PR TITLE
Fix CUDA ppc64le/aarch64 migrator (final try)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -50,8 +50,8 @@ m2w64_fortran_compiler:        # [win]
 CMAKE_GENERATOR:               # [win]
   - NMake Makefiles            # [win]
 
-cuda_compiler:                 # [linux64 or win or aarch64 or ppc64le]
-  - nvcc                       # [linux64 or win or aarch64 or ppc64le]
+cuda_compiler:                 # [linux or win]
+  - nvcc                       # [linux or win]
 cuda_compiler_version:
   - None
   - 10.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -50,8 +50,8 @@ m2w64_fortran_compiler:        # [win]
 CMAKE_GENERATOR:               # [win]
   - NMake Makefiles            # [win]
 
-cuda_compiler:                 # [linux64 or win]
-  - nvcc                       # [linux64 or win]
+cuda_compiler:                 # [linux64 or win or aarch64 or ppc64le]
+  - nvcc                       # [linux64 or win or aarch64 or ppc64le]
 cuda_compiler_version:
   - None
   - 10.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -19,14 +19,14 @@ __migrator:
 
 arm_variant_type:              # [aarch64]
   - sbsa                       # [aarch64]
+
 c_compiler_version:            # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
 cxx_compiler_version:          # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
 fortran_compiler_version:      # [ppc64le or aarch64]
   - 10                         # [ppc64le or aarch64]
-cuda_compiler:                 # [ppc64le or aarch64]
-  - nvcc                       # [ppc64le or aarch64]
+
 cuda_compiler_version:         # [ppc64le or aarch64]
   - 11.2                       # [ppc64le or aarch64]
 


### PR DESCRIPTION
Follow-up of #2690. 

Verified locally (by intercepting the global pinning inside conda-smithy and rewriting it). This is needed to make `conda_build.api.render()` know the existence of `cuda_compiler` on the supported platforms. Otherwise it'd mistakenly generate entries like `cuda_linux-aarch64`, which should not happen as back in the old days overwriting with a local cbc.yaml worked. 

cc: @isuruf @jakirkham @kkraus14 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
