### PR TITLE
Bump CUDA arch migrator number to re-run migration

### DIFF
--- a/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    1
+    2
   build_number:
     1
   paused: false


### PR DESCRIPTION
See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2695#issuecomment-1086276556. In #2695 we fixed the migrator, and it turns out all prior migrator runs were invalid as no real work was done due to the global pinning error.

cc: @jakirkham @isuruf @kkraus14 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
