### PR TITLE
Add ffmpeg5 migration for unix

### DIFF
--- a/recipe/migrations/ffmpeg5.yaml
+++ b/recipe/migrations/ffmpeg5.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1649161119
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+ffmpeg:
+  - 5    # [unix]
+  - 4.3  # [win]


### PR DESCRIPTION
I really wish we could update cleanly, however, a few attempts of mine have failed to get ffmpeg to build:

* https://github.com/conda-forge/ffmpeg-feedstock/pull/126
* https://github.com/conda-forge/ffmpeg-feedstock/pull/124

Thoughts on moving forward with this?


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
