### PR TITLE
add sourmash-minimal to osx_arm64 migration list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -812,3 +812,4 @@ clhep
 healpix_cxx
 pmw
 pykep
+sourmash-minimal


### PR DESCRIPTION
I think all [sourmash-minimal](https://github.com/conda-forge/sourmash-minimal-feedstock) deps are available in `osx_arm64`, so adding it to the list.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)