### PR TITLE
use numpy 1.19 consistently for python & pypy 3.8/3.9

### DIFF
--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -42,8 +42,8 @@ numpy:
   - 1.19
   - 1.19
   - 1.21
-  - 1.22               # [not (osx and arm64)]
-  - 1.22               # [not (osx and arm64)]
+  - 1.19               # [not (osx and arm64)]
+  - 1.19               # [not (osx and arm64)]
 python_impl:
   - cpython            # [not (osx and arm64)]
   - cpython


### PR DESCRIPTION
Since the backport turned out to work without issue (cf. https://github.com/conda-forge/numpy-feedstock/pull/264; most of the changes were backports from work that had happened since then on master/main), I propose to use the same numpy host-version across cpython/pypy 3.8 & 3.9. I've also prepared backports for 1.20 & 1.21 so we can then consistently bump the version according to NEP29.