### PR TITLE
Close out pulse audio since it is only waiting for packages that were already built correctly

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -685,6 +685,8 @@ poppler:
   - '22.01'
 proj:
   - 8.2.1
+pulseaudio:
+  - 14.0
 pybind11_abi:
   - 4
 python:

--- a/recipe/migrations/pulseaudio140.yaml
+++ b/recipe/migrations/pulseaudio140.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1649204305
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-pulseaudio:
-  - 14.0


### PR DESCRIPTION
Its waiting on qt-main and its dependnecies,
https://github.com/conda-forge/qt-main-feedstock/pull/20

but they were already built with PulseAudio 14.0

I was trying to ensure that old packages were rebuilt, that is now done.

Lets close this and let qt-main update at its own pace.
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
