### PR TITLE
Add python-casacore to osx_arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -827,3 +827,4 @@ pygcgopt
 pyshtools
 libconeangle
 celerite
+python-casacore


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Adding python-casacore to the list for osx_arm64 migration per instructions here: https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/