### PR TITLE
Close out Pytorch 1.11 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -706,7 +706,7 @@ python_impl:
   - cpython
   - cpython
 pytorch:
-  - '1.10'
+  - '1.11'
 qt:
   - 5.12
 qtkeychain:

--- a/recipe/migrations/pytorch111.yaml
+++ b/recipe/migrations/pytorch111.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1647822259.0115824
-pytorch:
-- '1.11'


### PR DESCRIPTION
The three packages that remain:

- torchani: https://github.com/conda-forge/torchani-feedstock/pull/8
- fcos: https://github.com/conda-forge/fcos-feedstock/pull/6
- nnpops (waiting on torchani https://github.com/conda-forge/fcos-feedstock/pull/6#issuecomment-1109020273)


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
