### PR TITLE
Add `ucx` to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -759,6 +759,8 @@ tk:
   - 8.6                # [not ppc64le]
 tiledb:
   - '2.7'
+ucx:
+  - 1.12.1
 uhd:
   - 4.1.0
 vc:                    # [win]


### PR DESCRIPTION
Start with the latest version 1.12.1, which added `run_exports`. Also relevant [ABI report]( https://abi-laboratory.pro/index.php?view=timeline&l=ucx ).

cc @conda-forge/ucx-split

xref: https://github.com/conda-forge/ucx-split-feedstock/pull/92/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR40-R41

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
