### PR TITLE
Dual abseil builds 20210324 and 20211102

### DIFF
--- a/recipe/migrations/abseil_cpp20210324_20211102.yaml
+++ b/recipe/migrations/abseil_cpp20210324_20211102.yaml
@@ -1,0 +1,13 @@
+migrator_ts: 1651842871
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+# hmaarrfk (2022/05/06)
+# Due to the fact that cetain large packages (tensorflow)
+# require specific versions of abseil to be used, it is
+# useful if we build out two versions with the abseil dependency
+abseil_cpp:
+- '20210324.2'
+- '20211102.0'

--- a/recipe/migrations/abseil_cpp20211102.yaml
+++ b/recipe/migrations/abseil_cpp20211102.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1644918847
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-abseil_cpp:
- - '20211102.0'


### PR DESCRIPTION
Due to the fact that cetain large packages (tensorflow)
require specific versions of abseil to be used, it is
useful if we build out two versions with the abseil dependency

See discussion: https://github.com/conda-forge/abseil-cpp-feedstock/issues/29
See discussion: https://github.com/conda-forge/grpc-cpp-feedstock/pull/138

cc: @xhochy 

The abseil migration seems to have been complete so i'm closing it out too.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
