### PR TITLE
Let lz4-c manage its own pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -262,8 +262,6 @@ pin_run_as_build:
     max_pin: x.x
   libuuid:
     max_pin: x
-  lz4-c:
-    max_pin: x.x.x
   lzo:
     max_pin: x
   metis:

--- a/recipe/migrations/lz4_c19.yaml
+++ b/recipe/migrations/lz4_c19.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1652241058
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+lz4_c:
+  - '1.9'

--- a/recipe/migrations/lz4_c19.yaml
+++ b/recipe/migrations/lz4_c19.yaml
@@ -5,4 +5,4 @@ __migrator:
   bump_number: 1
 
 lz4_c:
-  - '1.9'
+  - '1.9.3'


### PR DESCRIPTION
It seems that they only want to to pin to `x.x` not `x.x.x` 
https://github.com/conda-forge/lz4-c-feedstock/blob/main/recipe/meta.yaml#L37


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
