### PR TITLE
Update migrator for google_cloud_cpp 1.40

### DIFF
--- a/recipe/migrations/google_cloud_cpp_140.yaml
+++ b/recipe/migrations/google_cloud_cpp_140.yaml
@@ -1,8 +1,8 @@
-migrator_ts: 1652079610
+migrator_ts: 1652617312
 __migrator:
   kind: version
   migration_number: 1
   bump_number: 1
 
 google_cloud_cpp:
-  - "1.37"
+  - "1.40"


### PR DESCRIPTION
This is now out of date,
* There is only 1 feedstock that needs this.
* I've already had to fold it in due to other incomaptibilites in pinnings for this old version https://github.com/conda-forge/arrow-cpp-feedstock/pull/749


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
