### PR TITLE
Migrate to petsc 3.17

### DIFF
--- a/recipe/migrations/petsc317.yaml
+++ b/recipe/migrations/petsc317.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1652867610
+petsc:
+- '3.17'
+petsc4py:
+- '3.17'
+slepc:
+- '3.17'
+slepc4py:
+- '3.17'


### PR DESCRIPTION
<del>The petsc 3.16 migration still has two outstanding packages (daetk, proteus), [stuck on daetk](https://github.com/conda-forge/daetk-feedstock/pull/6). Should I complete the 3.16 migration here too, or let it keep going?</del> 3.16 migration is complete

closes #2732 
closes #2744