### PR TITLE
Add gepetto-viewer-corba to osx_arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -864,3 +864,4 @@ starship
 stow
 samtools
 bedtools
+gepetto-viewer-corba


### PR DESCRIPTION
There seems to be user interest (https://github.com/Gepetto/gepetto-viewer-corba/issues/164).

fyi @conda-forge/gepetto-viewer-corba 