### PR TITLE
Close out assimp 5.2.3 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -355,7 +355,7 @@ arrow_cpp:
   - 5.0.0
   - 4.0.1
 assimp:
-  - 5.2
+  - 5.2.3
 attr:
   - 2.5
 aws_c_auth:

--- a/recipe/migrations/assimp523.yaml
+++ b/recipe/migrations/assimp523.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-assimp:
-- 5.2.3
-migrator_ts: 1647746722.3763156


### PR DESCRIPTION
There are a few `hpp-*` packages missing, see: 
![hpp_pinocchio](https://user-images.githubusercontent.com/1857049/169652172-573d8c1b-f409-4987-84fc-3df92e7d8bb3.png)

However, as discussed in https://github.com/conda-forge/hpp-pinocchio-feedstock/pull/6#issuecomment-1131843557 those packages are not compiling in the current form for reason unrelated to assimp, and in particular are not compatible with the latest packages created by conda-forge . 

As assimp 5.2.4 has been released (see https://github.com/conda-forge/assimp-feedstock/pull/42), I think we can just close this migration an permit to the `hpp-*` mantainers to fix their packages during the assimp 5.2.4 migration.

cc @conda-forge/hpp-pinocchio 