### PR TITLE
Add pygeoda to arm migrators

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -532,3 +532,4 @@ pyfai
 quaternion
 meilisearch
 oras
+pygeoda

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -878,3 +878,4 @@ r-sf
 r-essentials
 dbgpy
 climlab-cam3-radiation
+pygeoda


### PR DESCRIPTION
Adding `pygeoda` to migrators for aarch64 and osx arm64.