### PR TITLE
Add pinning for libidn2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -543,6 +543,8 @@ libhwy:
   - 0.15
 libiconv:
   - 1.16
+libidn2:
+  - 2
 libintervalxt:
   - 3
 libkml:


### PR DESCRIPTION
Ever since the original recipe, this only existed as version 2. 

No need for migrator.

https://github.com/conda-forge/libidn2-feedstock/commit/ef40045fb8d7cf080937dc0a70a33a3d74f37dc6#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR1
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
