### PR TITLE
Add gazebo to arch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -537,3 +537,4 @@ dwave-ocean-sdk
 pyscf
 slepc
 fenics-dolfinx
+gazebo


### PR DESCRIPTION
Now that qt-main is available for aarch64, we can also add gazebo to the migration.