### PR TITLE
Add `pyomo` and `tabula-py`

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -912,3 +912,5 @@ r-ggforce
 pycifrw
 mdanalysis
 mdanalysistests
+tabula-py
+pyomo


### PR DESCRIPTION
* [`pyomo`](https://github.com/conda-forge/pyomo-feedstock) and
* [`tabula-py`](https://github.com/conda-forge/tabula-py-feedstock)

are also architecture-dependent packages that currently do not have support for `osx-amd64` architectures on Conda forge.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
