### PR TITLE
zip all cudatoolkits with cudnn8

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -64,7 +64,8 @@ cuda_compiler_version_min:
   - 11.2                       # [linux and (ppc64le or aarch64)]
 cudnn:
   - undefined
-  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 7                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"  and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
+  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"  and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
   - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Fix #3006 

we currently have the following:
- cudatoolkit==10.2 --> cudnn 7
- cudatoolkit>=11.0 --> cudnn 8

This *speculative* PR simply sets cudnn to 8 for all cudatoolkits. I am not sure what the rationale for setting cudnn to 7 was --- not documented as far as I could tell, but below are relevant issues:

- https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1050
- https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1051

@isuruf, since you've been involved in #1050 and #1051, do you have any thoughts on this? Thanks!



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
