### PR TITLE
relax abseil_cpp and grpc_cpp?

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -169,9 +169,6 @@ zip_keys:
     - python
     - numpy
     - python_impl
-  -
-    - abseil_cpp
-    - grpc_cpp
 
 
 # aarch64 specifics because conda-build sets many things to centos 6


### PR DESCRIPTION
Tensorflow can only be built with the latest version anyway, so we might as well move forward with these pins now? I would defer to isuruf, xhochy, and hmaarrfk on how to best move forward here. But my point is that we don't need to build 20210324.2 anymore.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
