### PR TITLE
Manually close out libmatio1521 migration

### DIFF
--- a/recipe/migrations/libmatio1521.yaml
+++ b/recipe/migrations/libmatio1521.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libmatio:
-- 1.5.21
-migrator_ts: 1644791060


### PR DESCRIPTION
The only missing package is https://github.com/conda-forge/trilinos-feedstock/pull/33, a package that it is known to be abandoned: https://github.com/conda-forge/conda-forge.github.io/issues/1724 . Furthermore, the pin of libmatio was already set to 1.5.21 by https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2467, see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1263 for details.


