### PR TITLE
Added cloudpathlib to osx_arm64 migration list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -937,3 +937,4 @@ geant4
 propka
 zeopp-lsmo
 raspa2
+cloudpathlib


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This PR add cloudpathlib to the list of packages for osx_arm64 builds.