### PR TITLE
Use ffmpeg version 4.4 for all platforms

### DIFF
--- a/recipe/migrations/ffmpeg44.yaml
+++ b/recipe/migrations/ffmpeg44.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1657582548
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+ffmpeg:
+  - 4.4


### PR DESCRIPTION
We previously had to use version 4.3 (pre-compiled) for windows, but we recently got builds for 4.4 (and pending builds for 5.0) for ffmpeg.

We are holding off on ffmpeg 5.0 since it seems many downstream packages have not had the chance to update yet.