### PR TITLE
Bump migration number for ffmpeg 4.4

### DIFF
--- a/recipe/migrations/ffmpeg44.yaml
+++ b/recipe/migrations/ffmpeg44.yaml
@@ -1,7 +1,7 @@
 migrator_ts: 1657582548
 __migrator:
   kind: version
-  migration_number: 1
+  migration_number: 2
   bump_number: 1
 
 ffmpeg:


### PR DESCRIPTION
I think because there was an other ffmpeg4.4 migration this number needs to be incremented.
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
