### PR TITLE
Add libmongocxx to arch migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -279,6 +279,7 @@ lcov
 lua
 python-blosc
 libdrm
+libmongocxx
 myproxy
 rrdtool
 gfal2-util


### PR DESCRIPTION
Rebuild https://github.com/conda-forge/libmongocxx-feedstock for Linux/ppc64le and Linux/aarch64.