### PR TITLE
Adding iteration_utilities to arm64 migration list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -955,3 +955,4 @@ r-reprex
 harp
 oso
 dionysus
+iteration_utilities


### PR DESCRIPTION
Needed to install `copier` on arm64.
