### PR TITLE
Abseil 20220623 migration (redux)

### DIFF
--- a/recipe/migrations/abseil_cpp202206230.yaml
+++ b/recipe/migrations/abseil_cpp202206230.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+
+# TODO: Make sure to remove the associated zip keys in the final file
+# when the migration is complete
+abseil_cpp:
+- '20220623.0'
+grpc_cpp:
+- '1.48'
+
+migrator_ts: 1656693919.0942996

--- a/recipe/migrations/abseil_cpp202206230.yaml
+++ b/recipe/migrations/abseil_cpp202206230.yaml
@@ -15,6 +15,6 @@ libabseil:
 libabseil_static:
 - '20220623.0'
 grpc_cpp:
-- '1.48'
+- '1.46'
 
 migrator_ts: 1656693919.0942996

--- a/recipe/migrations/abseil_cpp202206230.yaml
+++ b/recipe/migrations/abseil_cpp202206230.yaml
@@ -7,6 +7,13 @@ __migrator:
 # when the migration is complete
 abseil_cpp:
 - '20220623.0'
+# new name, use both for now
+libabseil:
+- '20220623.0'
+# separate output for static builds (depending on C++ version)
+# also need to be migrated
+libabseil_static:
+- '20220623.0'
 grpc_cpp:
 - '1.48'
 

--- a/recipe/migrations/abseil_cpp202206230.yaml
+++ b/recipe/migrations/abseil_cpp202206230.yaml
@@ -1,7 +1,7 @@
 __migrator:
   build_number: 1
   kind: version
-  migration_number: 1
+  migration_number: 2
 
 # TODO: Make sure to remove the associated zip keys in the final file
 # when the migration is complete

--- a/recipe/migrations/abseil_cpp_removal.yaml
+++ b/recipe/migrations/abseil_cpp_removal.yaml
@@ -1,0 +1,13 @@
+__migrator:
+  bump_number: 0
+  kind: deletion
+  migration_number: 1
+  wait_for_migrators:
+    - abseil_cpp202206230
+
+# TODO: Make sure to remove the associated zip keys in the final file
+# when the migration is complete
+abseil_cpp:
+- '20220623.0'
+
+migrator_ts: 1660061100


### PR DESCRIPTION
Follow-up to #3159, using the builds added in https://github.com/conda-forge/abseil-cpp-feedstock/pull/35. gRPC is passing with those builds in https://github.com/conda-forge/grpc-cpp-feedstock/pull/196. 

~This is obviously blocked on the abseil PR, but~ I wanted to see what changes would be necessary to take care of the `abseil_cpp` -> `libabseil` rename.

Closes #3220

CC @hmaarrfk @mariusvniekerk @xhochy 