### PR TITLE
[migrate osx-arm64] r-tidyverse

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -980,3 +980,4 @@ stack
 ghc
 openimageio
 py-openimageio
+r-tidyverse


### PR DESCRIPTION
Adds `r-tidyverse` to **osx-arm64** migration. This is a very common package that should trigger important dependent migrations, like `r-reprex` and `r-markdown`. Previously, this was impossible prior to the `pandoc` support for **osx-arm64**, which was recently added.