### PR TITLE
Closeout libprotobuf migration 3.20

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -587,7 +587,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - '3.19'
+  - '3.20'
 librdkafka:
   - '1.7'
 librsvg:

--- a/recipe/migrations/libprotobuf320.yaml
+++ b/recipe/migrations/libprotobuf320.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.20'
-migrator_ts: 1648312994.8337886


### PR DESCRIPTION
It seems the last two straggling ones are:

- qgis
- go-cockroach

which seem to be lagging in quite a few migrations.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
