### PR TITLE
Fix s2n pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -759,7 +759,7 @@ scotch:
 ptscotch:
   - 6.0.9
 s2n:
-  - 1.3.18
+  - 1.3.19
 singular:
   - 4.2.1.p3
 snappy:


### PR DESCRIPTION
The migrators were merged in the wrong order. This is the latest pin.