### PR TITLE
Fix aws_c_http pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -374,7 +374,7 @@ aws_c_common:
 aws_c_event_stream:
   - 0.2.9
 aws_c_http:
-  - 0.6.18
+  - 0.6.19
 aws_c_io:
   - 0.13.0
 aws_c_mqtt:


### PR DESCRIPTION
Migrators were merged in the wrong order.