### PR TITLE
Delete outdated aws migrations

### DIFF
--- a/recipe/migrations/aws_c_common074.yaml
+++ b/recipe/migrations/aws_c_common074.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_c_common:
-- 0.7.4
-migrator_ts: 1652718581.4483976

--- a/recipe/migrations/aws_c_event_stream0212.yaml
+++ b/recipe/migrations/aws_c_event_stream0212.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_c_event_stream:
-- 0.2.12
-migrator_ts: 1655891596.5841472

--- a/recipe/migrations/aws_sdk_cpp19300.yaml
+++ b/recipe/migrations/aws_sdk_cpp19300.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-aws_sdk_cpp:
-- 1.9.300
-migrator_ts: 1657878243.195235


### PR DESCRIPTION
Newer ones were already merged with an updated pin.