### PR TITLE
Adding Scalene OS X Arm64 build

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -991,3 +991,4 @@ parcels
 esptool
 armadillo
 redlionfish
+scalene


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Adding an OS X Arm 64 build per instructions given here: https://github.com/conda-forge/staged-recipes/pull/18747#issuecomment-1226603568

<!--
Please add any other relevant info below:
-->
