### PR TITLE
Ignore pyqt for matplotlib in pypy38

### DIFF
--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -27,6 +27,9 @@ __migrator:
       - python
       - pypy3.6
       - pypy-meta
+    ignored_deps_per_node:
+      matplotlib:
+        - pyqt
 
 python:
   - 3.8.* *_73_pypy    # [not (osx and arm64)]


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/conda-forge/matplotlib-feedstock/pull/322#issuecomment-1200449398 using the same method that was previously used in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1821.