### PR TITLE
Rebuild aarch64 for ephem

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -427,6 +427,7 @@ pythran
 scitokens
 scitokens-cpp
 awscrt
+ephem
 gst-libav
 gst-plugins-bad
 gst-plugins-ugly


### PR DESCRIPTION
In [ephem](https://github.com/conda-forge/ephem-feedstock/pull/29), something is [broken](https://github.com/conda-forge/prophet-feedstock/pull/30/checks?check_run_id=8279077218) with pypy on aarch64. I hope that this migration will somehow fix it.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
