### PR TITLE
Add a simple test for the readability of yaml files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,9 @@ build:
     - exit 1                                                          # [win]
 
 test:
+  requires:
+    - python >= 3.8
+    - pyyaml
   commands:
     - test -f $PREFIX/conda_build_config.yaml                       # [unix]
     - test -f $PREFIX/share/conda-forge/migrations/example.exyaml   # [unix]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,13 @@
+import yaml
+from pathlib import Path
+
+import os
+PREFIX = os.environ.get('PREFIX', os.environ.get('CONDA_PREFIX'))
+migrations_path = Path(PREFIX) / 'share' / 'conda-forge' / 'migrations'
+
+print(f"Checking migrations in {migrations_path}")
+
+for filename in migrations_path.glob('*.yaml'):
+    print(f"Checking that we can read {filename}")
+    with open(filename, 'r', encoding='utf-8') as f:
+        yaml.load(f, Loader=yaml.SafeLoader)


### PR DESCRIPTION
In https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3403 @izahn and I accidentally introduced an invalid yaml file.

This is a simple test that ensure that we can read all installed files.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
