### PR TITLE
Close out libiconv migration and respect new pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -251,8 +251,6 @@ pin_run_as_build:
     max_pin: x.x
   libgdal:
     max_pin: x.x
-  libiconv:
-    max_pin: x.x
   libkml:
     max_pin: x.x
   libpng:
@@ -566,7 +564,7 @@ libhugetlbfs:
 libhwy:
   - '1.0'
 libiconv:
-  - 1.16
+  - 1
 libidn2:
   - 2
 libintervalxt:

--- a/recipe/migrations/libiconv117.yaml
+++ b/recipe/migrations/libiconv117.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libiconv:
-- '1.17'
-migrator_ts: 1653640691.779616


### PR DESCRIPTION
cc @isuruf 

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2919#issuecomment-1242837444
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
