### PR TITLE
Remove pin_run_as_build for packages that have run_exports

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -189,140 +189,28 @@ BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
 # TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:
-  arpack:
-    max_pin: x.x.x
   boost:
     max_pin: x.x.x
   boost-cpp:
     max_pin: x.x.x
-  bzip2:
-    max_pin: x
-  cairo:
-    max_pin: x.x
-  curl:
-    max_pin: x
-  dbus:
-    max_pin: x
-  fftw:
-    max_pin: x
+  # TODO: add run_exports to the following feedstocks
   flann:
     max_pin: x.x.x
-  fontconfig:
-    max_pin: x
-  freetype:
-    max_pin: x
-  gdal:
-    max_pin: x.x
-  glew:
-    max_pin: x.x
-  glpk:
-    max_pin: x.x
-  gmp:
-    max_pin: x
   graphviz:
     max_pin: x
-  harfbuzz:
-    max_pin: x
-  hdf4:
-    max_pin: x.x
-  isl:
-    max_pin: x.x
-  jasper:
-    max_pin: x
-  jpeg:
-    max_pin: x
-  libjpeg_turbo:
-    max_pin: x
-  json-c:
-    max_pin: x.x
-  jsoncpp:
-    max_pin: x.x.x
-  kealib:
-    max_pin: x.x
-  krb5:
-    max_pin: x.x
-  libblitz:
-    max_pin: x.x
-  libcurl:
-    max_pin: x
-  libevent:
-    max_pin: x.x.x
-  libffi:
-    max_pin: x.x
-  libgdal:
-    max_pin: x.x
-  libiconv:
-    max_pin: x.x
-  libkml:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  librsvg:
-    max_pin: x
   libsvm:
-    max_pin: x.x
-  libtiff:
-    max_pin: x
-  libxml2:
-    max_pin: x.x
-  libuuid:
-    max_pin: x
-  lzo:
-    max_pin: x
-  metis:
-    max_pin: x.x
-  mpfr:
     max_pin: x
   netcdf-cxx4:
     max_pin: x.x
-  netcdf-fortran:
-    max_pin: x.x
-  nettle:
-    max_pin: x.x
-  nlopt:
-    max_pin: x.x.x
-  nss:
-    max_pin: x
-  nspr:
-    max_pin: x
   occt:
-    max_pin: x.x
-  openturns:
-    max_pin: x.x
-  openjpeg:
-    max_pin: x.x
-  pango:
     max_pin: x.x
   poppler:
     max_pin: x.x
-  qt:
-    max_pin: x.x
-  qtkeychain:
-    max_pin: x.x
-  readline:
-    max_pin: x
   r-base:
     max_pin: x.x
     min_pin: x.x
-  sox:
-    max_pin: x.x.x
-  sqlite:
-    max_pin: x
-  tk:
-    max_pin: x.x
-  tiledb:
-    max_pin: x.x
   vlfeat:
     max_pin: x.x.x
-  vtk:
-    max_pin: x.x.x
-  xz:
-    max_pin: x.x
-  zeromq:
-    max_pin: x.x  # [not win]
-    max_pin: x.x.x  # [win]
-  zlib:
-    max_pin: x.x
 
 # Pinning packages
 
@@ -397,7 +285,7 @@ bzip2:
 c_ares:
   - 1
 cairo:
-  - 1.16
+  - 1
 capnproto:
   - 0.10.2
 ccr:
@@ -439,7 +327,7 @@ flann:
 fmt:
   - '9'
 fontconfig:
-  - 2.13
+  - 2
 freetype:
   - 2
 gct:
@@ -479,7 +367,7 @@ glib:
 glog:
   - '0.6'
 glpk:
-  - 4.65
+  - 4
 gmp:
   - 6
 google_cloud_cpp:
@@ -566,7 +454,7 @@ libhugetlbfs:
 libhwy:
   - '1.0'
 libiconv:
-  - 1.16
+  - 1
 libidn2:
   - 2
 libintervalxt:
@@ -685,7 +573,7 @@ openexr:
 openh264:
   - '2.3'
 openjpeg:
-  - '2.4'
+  - '2'
 openmpi:
   - 4
 openssl:
@@ -695,7 +583,7 @@ openturns:
 orc:
   - 1.7.6
 pango:
-  - '1.48'
+  - '1'
 pari:
   - 2.13.* *_pthread
 perl:
@@ -821,7 +709,7 @@ xerces_c:
 xrootd:
   - '5'
 xz:
-  - 5.2
+  - 5
 zeromq:
   - 4.3.4
 zfp:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -187,8 +187,8 @@ BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
 cdt_arch: armv7l                          # [armv7l]
 BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
-# TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:
+  # boost is special, see https://github.com/conda-forge/boost-cpp-feedstock/pull/82
   boost:
     max_pin: x.x.x
   boost-cpp:

--- a/recipe/migrations/libiconv117.yaml
+++ b/recipe/migrations/libiconv117.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libiconv:
-- '1.17'
-migrator_ts: 1653640691.779616


### PR DESCRIPTION
And also use correct versions for pinning based on run_exports

Needs to after https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/316

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
