### PR TITLE
Close out openjpeg25 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -681,7 +681,7 @@ openexr:
 openh264:
   - '2.3'
 openjpeg:
-  - >=2.5,<3
+  - '>=2.5,<3'
 openmpi:
   - 4
 openssl:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -287,8 +287,6 @@ pin_run_as_build:
     max_pin: x.x
   openturns:
     max_pin: x.x
-  openjpeg:
-    max_pin: x.x
   pango:
     max_pin: x.x
   poppler:
@@ -683,7 +681,7 @@ openexr:
 openh264:
   - '2.3'
 openjpeg:
-  - '2.4'
+  - >=2.5,<3
 openmpi:
   - 4
 openssl:

--- a/recipe/migrations/openjpeg25.yaml
+++ b/recipe/migrations/openjpeg25.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1653640705.5821373
-openjpeg:
-- '2.5'


### PR DESCRIPTION
This lets the recipe manage its own pinnings which are looser than the original ones.

https://github.com/conda-forge/openjpeg-feedstock/blob/main/recipe/meta.yaml#L16

@isuruf  is this kind of syntax allowed?
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
