### PR TITLE
Add C++ library eclib

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -424,6 +424,8 @@ davix:
   - '0.8'
 dbus:
   - 1
+eclib:
+  - 20220621
 exiv2:
   - 0.27
 expat:


### PR DESCRIPTION
since eclib does not follow any semantic versioning scheme, we have to pin exactly. That's also what the `run_exports` of eclib does.