### PR TITLE
drop support for numpy 1.19 according to NEP 29

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -670,9 +670,9 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.19   # [not (osx and arm64)]
-  - 1.19
-  - 1.19
+  - 1.20   # [not (osx and arm64)]
+  - 1.20
+  - 1.20
   - 1.21
 occt:
   - 7.6

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -36,8 +36,8 @@ python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.19               # [not (osx and arm64)]
-  - 1.19               # [not (osx and arm64)]
+  - 1.20               # [not (osx and arm64)]
+  - 1.20               # [not (osx and arm64)]
 python_impl:
   - pypy               # [not (osx and arm64)]
   - pypy               # [not (osx and arm64)]


### PR DESCRIPTION
It's [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) time again, or rather, it was in June already:
> On Jun 21, 2022 drop support for NumPy 1.19 (initially released on Jun 20, 2020)

Previous PR along these lines https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2600