### PR TITLE
pin google_cloud_cpp to the patch version

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -476,7 +476,7 @@ glpk:
 gmp:
   - 6
 google_cloud_cpp:
-  - '2.2'
+  - '2.2.0'
 google_cloud_cpp_common:
   - 0.25.0
 googleapis_cpp:


### PR DESCRIPTION
I had forgotten that we change the inline namespace in each patch release.
