### PR TITLE
 Close out assimp 5.2.4 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -352,7 +352,7 @@ arrow_cpp:
   - 7.0.1
   - 6.0.2
 assimp:
-  - 5.2.3
+  - 5.2.4
 attr:
   - 2.5
 aws_c_auth:

--- a/recipe/migrations/assimp524.yaml
+++ b/recipe/migrations/assimp524.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-assimp:
-- 5.2.4
-migrator_ts: 1653640601.473587


### PR DESCRIPTION
Similarly to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2898, there are a few hpp-* packages that are still not complete the migration:
![assimp524](https://user-images.githubusercontent.com/1857049/191302597-019b7b82-b68c-4e0d-901d-a704b04f4b4a.svg)

but these packages also did not migrated to assimp 5.2.4, and the mantainers agree on just closing the 5.2.4 assimp migration (https://github.com/conda-forge/hpp-pinocchio-feedstock/pull/10#issuecomment-1252317109). 

As we have assimp 5.2.5 ready (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3424), probably we can just close 5.2.4 and start the 5.2.5 migration.

cc @conda-forge/assimp 