### PR TITLE
Start a migration for openh264 2.3.1

### DIFF
--- a/recipe/migrations/openh264231.yaml
+++ b/recipe/migrations/openh264231.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1664050861
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+openh264:
+  - '2.3.1'


### PR DESCRIPTION
I think I should wait an hour for the things to propagate through the CDNs

https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/319
https://github.com/conda-forge/openh264-feedstock/issues/22


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
