### PR TITLE
Add libsndfile migration to 1.1

### DIFF
--- a/recipe/migrations/libsndfile11.yaml
+++ b/recipe/migrations/libsndfile11.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libsndfile:
+  - 1.1
+migrator_ts: 1666022698


### PR DESCRIPTION
This adds a pin migration for `libsndfile` to version 1.1.

`libsndfile` has a `run_exports` with `max_pin="x.x"` and was updated to 1.1.0 a little over a week ago, but it does not currently have a global pin. Thus, we have a situation now where newly built packages will build against 1.1.0, but they in turn cannot be installed alongside packages that were built with the older 1.0 version and haven't by chance been rebuilt recently.

Clearly we need a global pin to handle this, so this will ensure everything is built against 1.1 and then the global pin can be added. (I'm not sure if this is how it would usually be handled, and perhaps it would also be appropriate to add a global pin to 1.0 with this same PR?)

@conda-forge/libsndfile for comment.
