### PR TITLE
Unpause libxml2 migration

### DIFF
--- a/recipe/migrations/libxml2210.yaml
+++ b/recipe/migrations/libxml2210.yaml
@@ -2,7 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  paused: True
 libxml2:
 - '2.10'
 migrator_ts: 1660820650.179783


### PR DESCRIPTION
There are little notes about why this migration was paused in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3274

I'm pretty sure isuruf paused this because we wanted to the unpinning correct.

https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/316/files#diff-562be9a7a061c064fe4ad276374912f7928d706ac1b5accf3216d1e64dee5312R828

Original bot PR: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3269

However, I really disagree with this kind of strategy. The new ffmpeg was built with libxml2 2.9 and now is not released in terms of its pinning.

I don't think we should be using repodata patches so liberally.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
