### PR TITLE
add pybcj to aarch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -385,6 +385,7 @@ scalene
 nasm
 bazel
 onednn
+pybcj
 lbaplocal
 heaptrack
 dirac-grid


### PR DESCRIPTION
Necessary for OpenSSL 3.0 in https://github.com/conda-forge/tokenizers-feedstock (when running upstream [tests](https://github.com/conda-forge/tokenizers-feedstock/pull/55))