### PR TITLE
take over lessons learned from 3.10 to 3.11 migration

### DIFF
--- a/recipe/migrations/python311.yaml
+++ b/recipe/migrations/python311.yaml
@@ -18,11 +18,15 @@ __migrator:
     paused: false
     longterm: True
     pr_limit: 5
+    max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
     exclude:
       # this shouldn't attempt to modify the python feedstocks
       - python
       - pypy3.6
       - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
 
 python:
   - 3.11.* *_cpython


### PR DESCRIPTION
Glad to see the migration started so promptly! 🥳 

However, numpy doesn't show up in the build graph, because `exclude_pinned_pkgs: false` is missing.

I looked at the last [state](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/6198d2a27e4792329b8d4db794afd839f5bad2ce/recipe/migrations/python310.yaml) of the 3.10 migration before it was removed, and the following diff came out of that.
