### PR TITLE
Increase pr_limit for Python 3.11 migration

### DIFF
--- a/recipe/migrations/python311.yaml
+++ b/recipe/migrations/python311.yaml
@@ -17,7 +17,7 @@ __migrator:
             - 3.9.* *_73_pypy
     paused: false
     longterm: True
-    pr_limit: 5
+    pr_limit: 40
     max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
     exclude:
       # this shouldn't attempt to modify the python feedstocks


### PR DESCRIPTION
As this seems to be going smoothly I propose we increase the PR limit, any thoughts @conda-forge/core?