### PR TITLE
Increase pr_limit for Python 3.11 migration

### DIFF
--- a/recipe/migrations/python311.yaml
+++ b/recipe/migrations/python311.yaml
@@ -17,7 +17,7 @@ __migrator:
             - 3.9.* *_73_pypy
     paused: false
     longterm: True
-    pr_limit: 15
+    pr_limit: 30
     max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
     exclude:
       # this shouldn't attempt to modify the python feedstocks


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Napkin math: If a bot run takes around 2 hours and we have 200 concurrent jobs available and we use 20 minutes per job with 6 platforms and 6 Python version, we have a 90 % load factor for 30 PRs per bot run.
... okay, those numbers are wildly inaccurate, but they at least give me a feeling about what we deal with.
(N.B.: We should lower again when people are active and do other things (incl. merging the PRs).)