### PR TITLE
Increase PR limit as py311 seems to have slowed down

### DIFF
--- a/recipe/migrations/python311.yaml
+++ b/recipe/migrations/python311.yaml
@@ -17,7 +17,7 @@ __migrator:
             - 3.9.* *_73_pypy
     paused: false
     longterm: True
-    pr_limit: 30
+    pr_limit: 60
     max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
     exclude:
       # this shouldn't attempt to modify the python feedstocks


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
