### PR TITLE
add migration for google_cloud_cpp 2.3.0

### DIFF
--- a/recipe/migrations/google_cloud_cpp230.yaml
+++ b/recipe/migrations/google_cloud_cpp230.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+
+# needs to pin down to patch level due to inline namespaces changing, see
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3430
+google_cloud_cpp:
+- '2.3.0'
+
+migrator_ts: 1667209142.8457868


### PR DESCRIPTION
This one did not get picked up by the bot and is now needed to unblock the grpc migration.

See discussion in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3430 about how this needs to pin down to patch level.

CC @conda-forge/google-cloud-cpp @hmaarrfk 