### PR TITLE
Add gst_plugins_base to gstreamer migration

### DIFF
--- a/recipe/migrations/gstreamer121.yaml
+++ b/recipe/migrations/gstreamer121.yaml
@@ -1,9 +1,9 @@
 __migrator:
   build_number: 1
   kind: version
-  migration_number: 2
+  migration_number: 1
 gstreamer:
 - '1.21'
 gst_plugins_base:
 - '1.21'
-migrator_ts: 1667172469
+migrator_ts: 1664900131.838455

--- a/recipe/migrations/gstreamer121.yaml
+++ b/recipe/migrations/gstreamer121.yaml
@@ -1,7 +1,9 @@
 __migrator:
   build_number: 1
   kind: version
-  migration_number: 1
+  migration_number: 2
 gstreamer:
 - '1.21'
-migrator_ts: 1664900131.838455
+gst_plugins_base:
+- '1.21'
+migrator_ts: 1667172469


### PR DESCRIPTION
I found this bug while going through the qt main migration.

https://github.com/conda-forge/qt-main-feedstock/pull/58

Maybe somebody can double check this fix for the migration. I will likely work around it for qt
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
