### PR TITLE
Add pin for libsndfile 1.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -479,6 +479,8 @@ librsvg:
   - 2
 libsecret:
   - 0.18
+libsndfile:
+  - 1.1
 libspatialindex:
   - 1.9.3
 libssh:


### PR DESCRIPTION
This follows the completed migration from #3526 and #3623.