### PR TITLE
close out libprotobuf migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -472,7 +472,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - '3.20'
+  - '3.21'
 librdkafka:
   - '1.9'
 librsvg:

--- a/recipe/migrations/libprotobuf321.yaml
+++ b/recipe/migrations/libprotobuf321.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libprotobuf:
-- '3.21'
-migrator_ts: 1661531047.2553904


### PR DESCRIPTION
The last two remaining feedstocks are:
* [tomviz](https://github.com/conda-forge/tomviz-feedstock/pull/49), which is stuck because upstream only(!) supports python 3.7
* [go-cockroach](https://github.com/conda-forge/go-cockroach-feedstock), an abandoned feedstock which already missed the last two protobuf migrations

I don't consider waiting for either of those a good reason to forestall this further.

CC @conda-forge/libprotobuf @hmaarrfk 