### PR TITLE
Adds `thriftpy2` to arch_rebuild.txt to produce aarch64 and ppc64le package builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX                              # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   script:
     - cp conda_build_config.yaml $PREFIX                              # [unix]

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -609,3 +609,4 @@ laspy
 manim
 cds-crtools
 scikit-gstat
+thriftpy2


### PR DESCRIPTION
Adds `thriftpy2` to arch_rebuild.txt to produce aarch64 and ppc64le package builds for [thriftpy2](https://github.com/conda-forge/thriftpy2-feedstock).

fyi: @jakirkham @bdice 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist _(removed checks that were not relevant)_
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
