### PR TITLE
Add pytango to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -863,6 +863,7 @@ cpptango
 tango-admin
 tango-database
 tango-test
+pytango
 omniorb
 celery
 pystackreg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)


The stable version (9.3) of `pytango` isn't available for osx.
We added support in 9.4.0rc1 which was published in the `rc` branch: https://github.com/conda-forge/pytango-feedstock/tree/rc

We'd like to make it available for osx-arm64. Is it possible to create a migration for the rc branch? The PR target branch can maybe be changed after the PR creation? Or do we need to wait for this version to be available in main?