### PR TITLE
add nifty to osx_arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1063,3 +1063,4 @@ somoclu
 cellfinder-core
 scikit-sparse
 scikit-network
+nifty


### PR DESCRIPTION
Dear conda-forge team,

I'd like to add the nifty package to the osx_arm64 migration.

Thank you!
Cheers
Dominik


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* n/a Bumped the build number (if the version is unchanged)
* n/a Reset the build number to `0` (if the version changed)
* n/a [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* n/a Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
