### PR TITLE
add missing libgrpc pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -375,6 +375,7 @@ googleapis_cpp:
   - '0.10'
 graphviz:
   - '6'
+# keep in sync with libgrpc
 grpc_cpp:
   - '1.49'
 harfbuzz:
@@ -447,6 +448,8 @@ libgdal:
   - '3.5'
 libgit2:
   - '1.5'
+libgrpc:
+  - '1.49'
 libhugetlbfs:
   - 2
 libhwy:


### PR DESCRIPTION
Follow-up to #3606 / #3713; the former added an alias (now primary output), while the latter PR did not set that in the global cbc.

CC @xhochy @ocefpaf since you merged those two PRs