### PR TITLE
Add gdal to libgdal 3.6 migrator

### DIFF
--- a/recipe/migrations/libgdal36.yaml
+++ b/recipe/migrations/libgdal36.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+gdal:
+- '3.6'
 libgdal:
 - '3.6'
 migrator_ts: 1668608830.3535678


### PR DESCRIPTION
Manually adding GDAL 3.6 to the libgdal 3.6 migrator in #3726.

See also previous migrations for GDAL 3.5 (#2904), GDAL 3.4 (#2215), and so on.

Cc @conda-forge/gdal.