### PR TITLE
Add pyqt, pyqtwebengine, pyqtcharts to qt 5.15 migration

### DIFF
--- a/recipe/migrations/qt515.yaml
+++ b/recipe/migrations/qt515.yaml
@@ -8,3 +8,10 @@ qt:
   - 5.15
 qt_main:
   - 5.15
+# Upon closing, please rerember to add the pyqt to the global pinnings
+pyqt:
+  - 5.15
+pyqtwebengine:
+  - 5.15
+pyqtchart:
+  - 5.15


### PR DESCRIPTION
It seems that some packages are pinned to 5.12 since they depend on pyqt and it isn't being migrated even though it has a run export of 'x.x'.

xref: https://github.com/conda-forge/lxml-feedstock/issues/75#issuecomment-1330774288


I think this should help those people move forward in the qt 5.15 migration.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
