### PR TITLE
Add a global pinning for libsqlite to avoid implicitely pulling readline

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -494,6 +494,9 @@ libssh2:
   - 1
 libsvm:
   - '325'
+# keep libsqlite in sync with sqlite
+libsqlite:
+  - 3
 libthrift:
   - 0.16.0
 libtiff:
@@ -664,6 +667,7 @@ sox:
   - 14.4.2
 spdlog:
   - '1.10'
+# keep sqlite in sync with libsqlite
 sqlite:
   - 3
 starlink_ast:


### PR DESCRIPTION
This change was introduced in
https://github.com/conda-forge/sqlite-feedstock/pull/79

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
