### PR TITLE
Add migration for postgresql 15

### DIFF
--- a/recipe/migrations/libpq15.yaml
+++ b/recipe/migrations/libpq15.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1669902126
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libpq:
+  - 15
+postgresql:
+  - 15
+postgresql-plpython:
+  - 15

--- a/recipe/migrations/libpq15.yaml
+++ b/recipe/migrations/libpq15.yaml
@@ -8,5 +8,5 @@ libpq:
   - 15
 postgresql:
   - 15
-postgresql-plpython:
+postgresql_plpython:
   - 15


### PR DESCRIPTION
cc: @conda-forge/postgresql

This doesn't seem to have a current pinning, so many of my packages are defaulting to 14. 

- [ ] Should we "set the current pinning to 14"?
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
