### PR TITLE
Update pin for arrow_cpp / libarrow

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -170,6 +170,10 @@ zip_keys:
     - python
     - numpy
     - python_impl
+  # transition until arrow_cpp can be dropped for arrow 13.x
+  -
+    - arrow_cpp
+    - libarrow
 
 
 # aarch64 specifics because conda-build sets many things to centos 6
@@ -238,6 +242,7 @@ arb:
   - '2.23'
 arpack:
   - 3.7
+# keep in sync with libarrow
 arrow_cpp:
   - 9.0.0
   - 8.0.1
@@ -418,6 +423,12 @@ libabseil_static:
   - '20220623.0'
 libarchive:
   - 3.5
+# keep in sync with arrow_cpp (libarrow exists only from 10.x, but ensure consistency)
+libarrow:
+  - 9.0.0
+  - 8.0.1
+  - 7.0.1
+  - 6.0.2
 libavif:
   - 0.11.1
 libblitz:

--- a/recipe/migrations/arrow_cpp10.yaml
+++ b/recipe/migrations/arrow_cpp10.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+arrow_cpp:
+- '10'
+migrator_ts: 1670146930.791868

--- a/recipe/migrations/arrow_cpp10.yaml
+++ b/recipe/migrations/arrow_cpp10.yaml
@@ -7,4 +7,11 @@ arrow_cpp:
 - 9.0.0
 - 8.0.1
 - 7.0.1
+# make sure we have same length for zip, even
+# though libarrow builds only exist since 10.x
+libarrow:
+- 10.0.1
+- 9.0.0
+- 8.0.1
+- 7.0.1
 migrator_ts: 1670146930.791868

--- a/recipe/migrations/arrow_cpp10.yaml
+++ b/recipe/migrations/arrow_cpp10.yaml
@@ -3,5 +3,8 @@ __migrator:
   kind: version
   migration_number: 1
 arrow_cpp:
-- '10'
+- 10.0.1
+- 9.0.0
+- 8.0.1
+- 7.0.1
 migrator_ts: 1670146930.791868


### PR DESCRIPTION
In https://github.com/conda-forge/arrow-cpp-feedstock/pull/875, arrow finally shed the python-dependence of `arrow-cpp`, which we had been waiting for to finally [rename](https://github.com/conda-forge/arrow-cpp-feedstock/pull/158) that output to `libarrow`.

In the context of https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3203, it was explicitly decided to only keep building for the last 4 arrow versions, which is what I'm proposing here as well:
> @kkraus14: This removes the older two versions and adds the newest two versions to keep us at 4 versions of Arrow being pinned.

> @kkraus14: Brought this up in the core meeting and there was no objections, so going to merge this in a few hours unless there's any feedback before then.

In order to make sure we don't accidentally get misrenderings (or unintentionally unpin something), I think we should immediately add `libarrow` to the pinning and zip it with `arrow_cpp`, even if there are no builds before 10.x. That way at least the errors will be obvious.
 
My plan is that once arrow 13.x rolls around, we can fully switch to `libarrow` in the pinning (as {10, 11, 12, 13} = most recent 4 versions would then all have `libarrow` outputs).

Continues from #3792

Closes #3792
