### PR TITLE
add migration for google_cloud_cpp 2.5.0

### DIFF
--- a/recipe/migrations/google_cloud_cpp250.yaml
+++ b/recipe/migrations/google_cloud_cpp250.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+
+# needs to pin down to patch level due to inline namespaces changing, see
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3430
+google_cloud_cpp:
+- '2.5.0'
+
+migrator_ts: 1670190924.8093572

--- a/recipe/migrations/google_cloud_cpp250.yaml
+++ b/recipe/migrations/google_cloud_cpp250.yaml
@@ -8,4 +8,7 @@ __migrator:
 google_cloud_cpp:
 - '2.5.0'
 
+libgoogle_cloud:
+- '2.5.5'
+
 migrator_ts: 1670190924.8093572


### PR DESCRIPTION
Not sure why the bot doesn't open PRs for this one anymore - we already discussed this in the [PR](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3618) for 2.3.0, and the bot didn't open one for either 2.4 or 2.5 🤷 

CC @conda-forge/google-cloud-cpp @hmaarrfk 