### PR TITLE
add pin for sdl2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -657,6 +657,8 @@ ptscotch:
   - 6.0.9
 s2n:
   - 1.3.28
+sdl2:
+  - '2'
 singular:
   - 4.2.1.p3
 snappy:


### PR DESCRIPTION
Partially addresses #3809; other sdl2_* packages can follow once they've been properly updated & rebuilt.

Note that this doesn't need a migration because 2.x has been around since ages, and is _still_ the most recent available package. The run-export on the feedstock is also [set](https://github.com/conda-forge/sdl2-feedstock/blob/07959801a1f0e07c14a53f85d9124fce12715e9d/recipe/meta.yaml#L18) to major version.

A code search shows that a few packages would gain a pin, whereas adding this would allow (properly) removing the currently existing pins in `sdl2_{gfx,image,mixer,ttf}` feedstocks