### PR TITLE
add sdl_* and mpg123 to global pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -533,6 +533,8 @@ mkl:
   - 2022
 mkl_devel:
   - 2022
+mpg123:
+  - '1.31'
 mpich:
   - 4
 mpfr:
@@ -658,6 +660,14 @@ ptscotch:
 s2n:
   - 1.3.28
 sdl2:
+  - '2'
+sdl2_image:
+  - '2'
+sdl2_mixer:
+  - '2'
+sdl2_net:
+  - '2'
+sdl2_ttf:
   - '2'
 singular:
   - 4.2.1.p3


### PR DESCRIPTION
Closes #3809

I've added run-exports to all the SDL2_* packages (and updated them where necessary; only pending https://github.com/conda-forge/sdl2_net-feedstock/pull/8), and verified [usages](https://github.com/search?q=org%3Aconda-forge%20-%20mpg123&type=code) of `mpg123` in conda-forge are all unpinned (and hence would pull in the newest one anyway).

