### PR TITLE
Add cosmosis-build-standard-library to migration list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1101,3 +1101,4 @@ sdl2_ttf
 sdl2_image
 dvc
 r-rcppspdlog
+cosmosis-build-standard-library


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* N/A Bumped the build number (if the version is unchanged)
* N/A Reset the build number to `0` (if the version changed)
* N/A [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* N/A Ensured the license file is being packaged.

This adds the package cosmosis-standard-library to the OSX ARM64 migration list.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
