### PR TITLE
actually close aws_sdk_cpp 1.9.x migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -275,7 +275,7 @@ aws_checksums:
 aws_crt_cpp:
   - 0.18.16
 aws_sdk_cpp:
-  - 1.9.375
+  - 1.9.379
 boost:
   - 1.78.0
 boost_cpp:


### PR DESCRIPTION
#3735 should not have been merged yet, all the maintenance branches in arrow were still open (until https://github.com/conda-forge/arrow-cpp-feedstock/issues/918 was closed today).

Also, I've been using `1.9.379` for all those builds, because that's the last release in the 1.9.x series which has a migration [branch](https://github.com/conda-forge/aws-sdk-cpp-feedstock/tree/v1.9.x) that keeps it up-to-date w.r.t. to all the other aws-* migrations.

Bumping directly is fine because arrow is the only consumer, and all maintenance branches use 1.9.379.

CC @conda-forge/aws-sdk-cpp @ocefpaf 

PS. It would be nice to have the ABI branches be taken into account for the bot (and show up on the status page...)