### PR TITLE
add python-chromedriver-binary to osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -39,6 +39,7 @@ libtool
 autoconf
 automake
 m4
+python-chromedriver-binary
 patch
 git
 pytest


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Notes:
- for https://github.com/conda-forge/python-chromedriver-binary-feedstock/issues/96