### PR TITLE
Add packages triqs triqs_cthyb triqs_tprf triqs_dft_tools to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1133,3 +1133,7 @@ ibm_db_sa
 geocat-f2py
 pikepdf
 qscintilla2
+triqs
+triqs_cthyb
+triqs_tprf
+triqs_dft_tools


### PR DESCRIPTION
Add packages triqs triqs_cthyb triqs_tprf triqs_dft_tools to osx_arm64.txt to enable
bot-generated PR's enabling osx_arm64 builds.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->