### PR TITLE
Close out poppler migrations

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -631,7 +631,7 @@ pixman:
 poco:
   - 1.12.4
 poppler:
-  - '22.04'
+  - '22.12'
 proj:
   - 9.1.0
 pulseaudio:

--- a/recipe/migrations/poppler2210.yaml
+++ b/recipe/migrations/poppler2210.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1666191530.6962967
-poppler:
-- '22.10'

--- a/recipe/migrations/poppler2211.yaml
+++ b/recipe/migrations/poppler2211.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1667394448.9927871
-poppler:
-- '22.11'

--- a/recipe/migrations/poppler2212.yaml
+++ b/recipe/migrations/poppler2212.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1670688412.2831829
-poppler:
-- '22.12'


### PR DESCRIPTION
It seems that the remaining feedstocks haven't received many recent updates

- https://github.com/conda-forge/pdfgrep-feedstock
- https://github.com/conda-forge/pdf2svg-feedstock

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
