### PR TITLE
Add migrator for libraw 0.21

### DIFF
--- a/recipe/migrations/libraw021.yaml
+++ b/recipe/migrations/libraw021.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1673090267
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libraw:
+  - '0.21'


### PR DESCRIPTION
`libraw` is a shared library, but it is not pinned. Not a lot of packages depend on it (just `freeimage` and `openimageio`) but the number of indirect dependencies is higher, so it is a good idea to properly pin it.


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
