### PR TITLE
add gymnasium to arch-rebuilds

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -616,6 +616,7 @@ xcape
 libqdldl
 pykdtree
 ray-packages
+gymnasium
 noise
 lazrs-python
 laspy

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -588,6 +588,7 @@ x265
 nds2-client-swig
 cartographer
 gym
+gymnasium
 kaggle
 r-tidyverse
 quantecon


### PR DESCRIPTION
It's replacing gym, which is a dependency of ray-packages (both of which are targeted for rebuild already -- this way we can prepare the deps ahead of the next ray release, which will require gymnasium).