### PR TITLE
Add migrator for pcl 1.13.0

### DIFF
--- a/recipe/migrations/pcl1130.yaml
+++ b/recipe/migrations/pcl1130.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1673438406
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+pcl:
+  - '1.13.0'


### PR DESCRIPTION
As suggested by @h-veterinari in https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/17#issuecomment-1378627418, it would be convenient to have a pin on pcl (that is a C++ shared library). As a first step, let's add a migrator.