### PR TITLE
Close vtk922 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -736,7 +736,7 @@ vlfeat:
 volk:
   - '2.5'
 vtk:
-  - 9.1.0
+  - 9.2.2
 wcslib:
   - '7.7'
 wxwidgets:

--- a/recipe/migrations/vtk922.yaml
+++ b/recipe/migrations/vtk922.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1665352816.4914088
-vtk:
-- 9.2.2


### PR DESCRIPTION
The PR for the vtk925 migration was already merged (see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3926), but I guess it did not started because the vtk922 migration is still ongoing. 

As only three leaf feedstocks are missing (https://github.com/conda-forge/pyg4ometry-feedstock/pull/9, https://github.com/conda-forge/vmtk-feedstock/pull/12, https://github.com/conda-forge/freecad-feedstock/pull/81), I think we can close the migration, so we can start the vtk925 migration. This is quite important also because vtk922 was never migrated to libtiff 4.5 , and this is creating subtle incompatibilities such as the one discussed in https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/17#issuecomment-1378693395 .