### PR TITLE
close libffi migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -453,7 +453,7 @@ libevent:
 libexactreal:
   - 2
 libffi:
-  - '3.3'
+  - '3.4'
 libflatsurf:
   - 3
 libflint:

--- a/recipe/migrations/libffi34.yaml
+++ b/recipe/migrations/libffi34.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libffi:
-- '3.4'
-migrator_ts: 1630622620.3080156


### PR DESCRIPTION
This migration has been open since September 2021, and everything is done except one feedstock that's [verging](https://github.com/conda-forge/ghc-feedstock/pulls) on being abandoned (CC @conda-forge/ghc)

Close this migration, so the bot doesn't have to retry this all the time. ghc will need some major fixes anyway, having to deal with a newer libffi version won't matter.