### PR TITLE
Add pyqg package to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1145,3 +1145,4 @@ causalml
 gnuastro
 pathos
 forestci
+pyqg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

--- 

I was able to follow the instructions [here](https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock) and successfully apply the cross-compile config to build locally. A small nit, on my M1 MBP (still running MacOS 12.5), I had to export an environmental variable `export OSX_SDK_DIR=$HOME/software/tmp/SDKs` in order for the automated build system to successfully retrieve and use the archival SDK. Using an absolute path was important in order for the compiler to find standard headers like `stdio.h`.