### PR TITLE
add new migrator for libsentencepiece

### DIFF
--- a/recipe/migrations/libsentencepiece0197.yaml
+++ b/recipe/migrations/libsentencepiece0197.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+libsentencepiece:
+  - '0.1.97'
+migrator_ts: 1674388481.3029141


### PR DESCRIPTION
Now that torchtext is depending on this, we should have a pinning for libsentencepiece. I just merged https://github.com/conda-forge/sentencepiece-feedstock/pull/34, so now's a good time to add a new migrator