### PR TITLE
close pytorch 1.13 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -659,7 +659,7 @@ python_impl:
   - cpython
   - cpython
 pytorch:
-  - '1.12'
+  - '1.13'
 qt:
   - 5.12
 qtkeychain:

--- a/recipe/migrations/pytorch113.yaml
+++ b/recipe/migrations/pytorch113.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-pytorch:
-- '1.13'
-migrator_ts: 1670689494.5051908


### PR DESCRIPTION
The bot did not take well to dropping CUDA<11.2 for pytorch, but I've [worked](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3826#issuecomment-1366612441) through all of them manually now.

There's a couple PRs still left to merge, but all feedstocks are ready:
* [x] https://github.com/conda-forge/detectron2-feedstock/pull/37
* [ ] https://github.com/conda-forge/fcos-feedstock/pull/12 (merge https://github.com/conda-forge/fcos-feedstock/pull/11 first)
* [ ] https://github.com/conda-forge/nnpops-feedstock/pull/15
* [x] https://github.com/conda-forge/openmm-torch-feedstock/pull/31 (bumped to 1.13 without including migrator, so it shows as not solvable on the status page)
* [ ] https://github.com/conda-forge/pytorch_sparse-feedstock/pull/47 (optionally https://github.com/conda-forge/pytorch_sparse-feedstock/pull/46 first)