### PR TITLE
Migrate aws_sdk_cpp

### DIFF
--- a/recipe/migrations/aws_sdk_cpp11057.yaml
+++ b/recipe/migrations/aws_sdk_cpp11057.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_sdk_cpp:
+- 1.10.57
+migrator_ts: 1674532251.434477


### PR DESCRIPTION
Now that 1.11.0 has been released, we can definitely migrate to 1.10.x. More details about strategy going forward being discussed in https://github.com/conda-forge/aws-sdk-cpp-feedstock/issues/662

CC @conda-forge/aws-sdk-cpp

Based on #3988
Closes #3988
Closes #3982
Closes #3981
Closes #3976 
Closes #3954
Closes #3943
Closes #3936
Closes #3930
Closes #3927 
Closes #3925
Closes #3923
Closes #3921
Closes #3919
Closes #3908
Closes #3905
Closes #3904
Closes #3903
Closes #3899
Closes #3896
Closes #3894
Closes #3886
Closes #3877