### PR TITLE
Update pins in aws-c-* ecosystem

### DIFF
--- a/recipe/migrations/aws_c_auth0622.yaml
+++ b/recipe/migrations/aws_c_auth0622.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_auth:
+- 0.6.22
+migrator_ts: 1673599536.7484975

--- a/recipe/migrations/aws_c_auth0622.yaml
+++ b/recipe/migrations/aws_c_auth0622.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  wait_for_migrators:
+  - aws_c_common089
 aws_c_auth:
 - 0.6.22
 migrator_ts: 1673599536.7484975

--- a/recipe/migrations/aws_c_common089.yaml
+++ b/recipe/migrations/aws_c_common089.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_common:
+- 0.8.9
+migrator_ts: 1673680911.2455108

--- a/recipe/migrations/aws_c_common089.yaml
+++ b/recipe/migrations/aws_c_common089.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  wait_for_migrators:
+  - aws_c_event_stream0218
 aws_c_common:
 - 0.8.9
 migrator_ts: 1673680911.2455108

--- a/recipe/migrations/aws_c_event_stream0218.yaml
+++ b/recipe/migrations/aws_c_event_stream0218.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_event_stream:
+- 0.2.18
+migrator_ts: 1673574382.542301

--- a/recipe/migrations/aws_c_io01314.yaml
+++ b/recipe/migrations/aws_c_io01314.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_io:
+- 0.13.14
+migrator_ts: 1673680924.2678478

--- a/recipe/migrations/aws_c_io01314.yaml
+++ b/recipe/migrations/aws_c_io01314.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  wait_for_migrators:
+  - aws_c_auth0622
 aws_c_io:
 - 0.13.14
 migrator_ts: 1673680924.2678478

--- a/recipe/migrations/aws_c_s3023.yaml
+++ b/recipe/migrations/aws_c_s3023.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  wait_for_migrators:
+  - s2n1333
 aws_c_s3:
 - 0.2.3
 migrator_ts: 1674211540.9316928

--- a/recipe/migrations/aws_c_s3023.yaml
+++ b/recipe/migrations/aws_c_s3023.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_s3:
+- 0.2.3
+migrator_ts: 1674211540.9316928

--- a/recipe/migrations/s2n1333.yaml
+++ b/recipe/migrations/s2n1333.yaml
@@ -2,6 +2,8 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
+  wait_for_migrators:
+  - aws_c_io01314
 migrator_ts: 1674120201.4427557
 s2n:
 - 1.3.33

--- a/recipe/migrations/s2n1333.yaml
+++ b/recipe/migrations/s2n1333.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1674120201.4427557
+s2n:
+- 1.3.33


### PR DESCRIPTION
A couple of pent-up PRs that haven't been dealt with. Those run through fine with automerge, provided the different migrators don't deadlock, so order them with `wait_for_migrators`

Closes #3980 
Closes #3977
Closes #3953
Closes #3952
Closes #3950
Closes #3944
Closes #3942
Closes #3941
Closes #3940
Closes #3939
Closes #3922
Closes #3914

CC @xhochy