### PR TITLE
Add extra tango-controls packages to arch_rebuild

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -645,3 +645,8 @@ pypdf
 pytinyrenderer
 easyocr
 cpptango
+tango-database
+tango-access-control
+tango-admin
+tango-starter
+tango-test


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

`cpptango` was built without issue on linux-ppc64le and linux-aarch64. I'd like to build some extra tango-controls packages.