### PR TITLE
remove wait_for_migrators from aws_c_*

### DIFF
--- a/recipe/migrations/aws_c_auth0622.yaml
+++ b/recipe/migrations/aws_c_auth0622.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  wait_for_migrators:
-  - aws_c_common089
 aws_c_auth:
 - 0.6.22
 migrator_ts: 1673599536.7484975

--- a/recipe/migrations/aws_c_common089.yaml
+++ b/recipe/migrations/aws_c_common089.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  wait_for_migrators:
-  - aws_c_event_stream0218
 aws_c_common:
 - 0.8.9
 migrator_ts: 1673680911.2455108

--- a/recipe/migrations/aws_c_io01314.yaml
+++ b/recipe/migrations/aws_c_io01314.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  wait_for_migrators:
-  - aws_c_auth0622
 aws_c_io:
 - 0.13.14
 migrator_ts: 1673680924.2678478

--- a/recipe/migrations/aws_c_s3023.yaml
+++ b/recipe/migrations/aws_c_s3023.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  wait_for_migrators:
-  - s2n1333
 aws_c_s3:
 - 0.2.3
 migrator_ts: 1674211540.9316928

--- a/recipe/migrations/s2n1333.yaml
+++ b/recipe/migrations/s2n1333.yaml
@@ -2,8 +2,6 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-  wait_for_migrators:
-  - aws_c_io01314
 migrator_ts: 1674120201.4427557
 s2n:
 - 1.3.33


### PR DESCRIPTION
Now that `aws_c_event_stream0218` is fully done, unblock next migrator from #3991, while we investigate https://github.com/regro/cf-scripts/issues/1595