### PR TITLE
Add gst_plugin_base pinning update to gstreamer plugin update

### DIFF
--- a/recipe/migrations/gstreamer122.yaml
+++ b/recipe/migrations/gstreamer122.yaml
@@ -4,4 +4,6 @@ __migrator:
   migration_number: 1
 gstreamer:
 - '1.22'
+gst_plugins_base:
+- '1.22'
 migrator_ts: 1674863713.3234591


### PR DESCRIPTION
I've already updated a few repos to no longer depend on the gst_plugin_base dependency:

* [x] https://github.com/conda-forge/gstlal-feedstock/pull/32
* [x] https://github.com/conda-forge/kivy-feedstock/pull/49
* [x] https://github.com/conda-forge/wxpython-feedstock/pull/97
* [x] https://github.com/conda-forge/wxwidgets-feedstock/pull/29
* [x] https://github.com/conda-forge/gst-libav-feedstock/pull/28

I think that maybe we can get rid of this extra pinning altogether to avoid these kinds of mistakes.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
