### PR TITLE
Drop openturns pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -610,8 +610,6 @@ openmpi:
   - 4
 openssl:
   - '3'
-openturns:
-  - '1.20'
 orc:
   - 1.8.2
 pango:


### PR DESCRIPTION
Rationale: this almost only affects feedstocks I maintain (ot* submodules depends on openturns) and end up getting in the way of my manual updates trigerring unnecessary MRs
For other feedstocks (batman, libcxx) their are not updated frequently at all, and our api has become more stable anyways so this has become unnecessary (and we use exports x.x version)
