### PR TITLE
couple aws_c_http 0.7.4 to aws_c_common 0.8.10

### DIFF
--- a/recipe/migrations/aws_c_common0810.yaml
+++ b/recipe/migrations/aws_c_common0810.yaml
@@ -5,4 +5,8 @@ __migrator:
   automerge: true
 aws_c_common:
 - 0.8.10
+# coupled to aws_c_common version bump, see
+# https://github.com/conda-forge/aws-c-http-feedstock/pull/109
+aws_c_http:
+- 0.7.4
 migrator_ts: 1675487371.2696729

--- a/recipe/migrations/aws_c_io01315.yaml
+++ b/recipe/migrations/aws_c_io01315.yaml
@@ -5,4 +5,7 @@ __migrator:
   automerge: true
 aws_c_io:
 - 0.13.15
+# the builds got coupled because 0.2.4 landed before the io migrator
+aws_c_s3:
+- 0.2.4
 migrator_ts: 1675505277.067894


### PR DESCRIPTION
Quoting from https://github.com/conda-forge/aws-c-http-feedstock/pull/109:

> There's some unfortunate coupling here due to [awslabs/aws-c-common@b203e3f](https://github.com/awslabs/aws-c-common/commit/b203e3f26b56de79764139456384d6bfbc829140); just the version bump in https://github.com/conda-forge/aws-c-http-feedstock/pull/107 failed as well, i.e. we need to move both versions in sync to pass.

Rather than mess around with a separate migrator that will always need to be coupled to aws_c_common manually, just expand this one. It doesn't affect previously migrated packages for aws_c_common, because none of the children of aws-c-http have been migrated yet.

Ideally, this should be merged (just) before https://github.com/conda-forge/aws-c-http-feedstock/pull/109.

CC @conda-forge/aws-c-http @conda-forge/aws-c-common 
