### PR TITLE
also bump aws_c_s3 in aws_c_common0810

### DIFF
--- a/recipe/migrations/aws_c_common0810.yaml
+++ b/recipe/migrations/aws_c_common0810.yaml
@@ -9,4 +9,7 @@ aws_c_common:
 # https://github.com/conda-forge/aws-c-http-feedstock/pull/109
 aws_c_http:
 - 0.7.4
+# the builds got coupled because 0.2.4 landed before the this migrator finished
+aws_c_s3:
+- 0.2.4
 migrator_ts: 1675487371.2696729


### PR DESCRIPTION
Follow-up to #4074; overlooked that aws-c-s3 was one of the packages waiting for parents in the aws-c-common migrator.

CC @xhochy