### PR TITLE
add migrator for aws-crt-cpp

### DIFF
--- a/recipe/migrations/aws_crt_cpp0197.yaml
+++ b/recipe/migrations/aws_crt_cpp0197.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_crt_cpp:
+- 0.19.7
+migrator_ts: 1676588520.6231658


### PR DESCRIPTION
This was already necessary for https://github.com/conda-forge/aws-sdk-cpp-feedstock/pull/695 & https://github.com/conda-forge/aws-sdk-cpp-feedstock/pull/696, and is similarly necessary for arrow etc. resp. will be soon.

CC @conda-forge/aws-crt-cpp @xhochy 