### PR TITLE
sync libarrow with arrow_cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -248,8 +248,6 @@ arrow_cpp:
   - 10.0.1
   - 9.0.0
   - 8.0.1
-# make sure we have same length for zip, even
-# though libarrow builds only exist since 10.x
 assimp:
   - 5.2.5
 attr:
@@ -434,12 +432,13 @@ libaec:
   - '1'
 libarchive:
   - '3.6'
-# keep in sync with arrow_cpp (libarrow exists only from 10.x, but ensure consistency)
+# keep in sync with arrow_cpp (libarrow exists only from 10.x,
+# but make sure we have same length for zip as arrow_cpp)
 libarrow:
+  - 11.0.0
   - 10.0.1
   - 9.0.0
   - 8.0.1
-  - 7.0.1
 libavif:
   - 0.11.1
 libblitz:

--- a/recipe/migrations/libarrow1100.yaml
+++ b/recipe/migrations/libarrow1100.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libarrow:
-- 11.0.0
-- 10.0.1
-migrator_ts: 1677122846.5773642


### PR DESCRIPTION
There's only one dependence on libarrow, which is [stuck](https://github.com/conda-forge/r-arrow-feedstock/pull/61) on a missing migration for R 4.1.

As discussed in #4138, `libarrow` and `arrow_cpp` should remain in sync until we can drop support for arrow 9. In the meantime, it's better to follow up https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4136 with this than to wait for the solution to the missing R builds.

Also move some comments around that the migrator inserted in an awkward place.

CC @kkraus14 @xhochy 