### PR TITLE
undo bump to non-existent abseil-cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -229,9 +229,9 @@ blas_impl:
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
-# keep in sync with libabseil{,_static}
+# this output was dropped as of libabseil 20230125
 abseil_cpp:
-  - '20230125'
+  - '20220623.0'
 alsa_lib:
   - 1.2.8
 antic:


### PR DESCRIPTION
We dropped the old name of the abseil library in https://github.com/conda-forge/abseil-cpp-feedstock/pull/53, but the bot still [bumped](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4092) the output for some reason.

I'm not sure what the policy is for outputs that aren't active anymore, but I guess it doesn't hurt to keep them in the global pinning for a while longer, to ensure that people using the old output (e.g. in an old feedstock branch) still get _something_ when rerendering.

CC @conda-forge/abseil-cpp 