### PR TITLE
Add bash completion packages to osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1190,3 +1190,5 @@ verilator
 xeus-cling
 sqsgenerator
 cascade
+conda-bash-completion
+mamba-bash-completion


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Following instructions on
https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/ I am adding the packages conda-bash-completion and mamba-bash-completion to the list of packages supporting osx-arm64 architecture. These are purely Bash-script pacakges, no binary, so no complication.

(In theory) resolves tartansandal/mamba-bash-completion#2, resolves tartansandal/conda-bash-completion#18.
<!--
Please add any other relevant info below:
-->
