### PR TITLE
Pause jpeg turbo migration for version number bump

### DIFF
--- a/recipe/migrations/jpeg_to_libjpeg_turbo.yaml
+++ b/recipe/migrations/jpeg_to_libjpeg_turbo.yaml
@@ -4,6 +4,7 @@ __migrator:
   migration_number: 2
   bump_number: 1
   commit_message: "Rebuild for jpegturbo migration"
+  paused: true
 
 
 libjpeg_turbo:


### PR DESCRIPTION
Lets build 2.1.5 (which was released a little bit ago) to ensure that it can't be co-installed with jpeg.
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
