### PR TITLE
Add elfutils to global pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -322,6 +322,8 @@ dcap:
   - 2.47
 eclib:
   - '20221012'
+elfutils:
+  - 0.189
 exiv2:
   - 0.27
 expat:


### PR DESCRIPTION
Adds elfutils to the global pinning. It has a run export and has some shared libraries within it that some packages seem to link against.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.