### PR TITLE
Add pin for pcl

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -625,6 +625,8 @@ pango:
   - 1.50
 pari:
   - 2.15.* *_pthread
+pcl:
+  - 1.13.0
 perl:
   - 5.32.1
 petsc:


### PR DESCRIPTION
As originally suggested in https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/17#issuecomment-1378627418, this PR adds a pin for the C++ library pcl (https://github.com/conda-forge/pcl-feedstock). The current version is 1.13.0, and the run_exports compatibility is `x.x.x`, see https://github.com/conda-forge/pcl-feedstock/blob/a4ee540f99916869cf065206b112048abe008a4e/recipe/meta.yaml#L19 . To ensure that all the dependent packages actually currently link 1.13.0 in we added a migrator in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3931 that was closed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4000 .



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
