### PR TITLE
drop support for numpy to 1.20 following NEP29

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -600,8 +600,8 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.20
-  - 1.20
+  - 1.21
+  - 1.21
   - 1.21
 occt:
   - '7.7'

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -36,8 +36,8 @@ python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.20               # [not (osx and arm64)]
-  - 1.20               # [not (osx and arm64)]
+  - 1.21               # [not (osx and arm64)]
+  - 1.21               # [not (osx and arm64)]
 python_impl:
   - pypy               # [not (osx and arm64)]
   - pypy               # [not (osx and arm64)]


### PR DESCRIPTION
It's [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) time again, which says
> On Jan 31, 2023 drop support for NumPy 1.20 (initially released on Jan 31, 2021)

Previous PRs along these lines: #3420 #2600 