### PR TITLE
r-marginaleffects migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -673,3 +673,4 @@ sqsgenerator
 cascade
 pymatgen
 scenepic
+r-marginaleffects

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1210,3 +1210,4 @@ r-udunits2
 r-gmm
 scenepic
 marching_cubes
+r-marginaleffects


### PR DESCRIPTION
The `r-marginaleffects` builds [switched from `noarch` to platform-specific](https://github.com/conda-forge/r-marginaleffects-feedstock/pull/9). This requests Arch and OSX ARM migrations.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
