### PR TITLE
add libint to osx_arm64 migrator

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1217,3 +1217,4 @@ rb-escape_utils
 pygplates
 dtaidistance
 netgen
+libint


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~Bumped the build number (if the version is unchanged)~
* ~Reset the build number to `0` (if the version changed)~
* ~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~
* ~Ensured the license file is being packaged.~

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
If it matters, I want the migrator PR on libint `main` as a template for the `dev` branch. I'll apply the changes to the `dev` branch by hand, but I'll take care not to deceive the migrator logic by closing the PR on `main`.