### PR TITLE
Add aws-session-manager-plugin to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1219,3 +1219,4 @@ dtaidistance
 netgen
 conda-ecosystem-user-package-isolation
 libint
+aws-session-manager-plugin


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~[ ] Bumped the build number (if the version is unchanged)~
* ~[ ] Reset the build number to `0` (if the version changed)~
* ~[ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~
* ~[ ] Ensured the license file is being packaged.~

Upstream have added OSX Arm64 support in the latest release https://github.com/aws/session-manager-plugin/releases/tag/1.2.463.0