### PR TITLE
add ucx migration

### DIFF
--- a/recipe/migrations/ucx1410.yaml
+++ b/recipe/migrations/ucx1410.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+ucx:
+- '1.14.0'
+migrator_ts: 1679152574.207815


### PR DESCRIPTION
ucx was added in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2847 and hasn't been updated since. Not sure what the bot is stumbling over, but it missed 1.13, and doesn't seem to picking up 1.14 either.

Following https://github.com/conda-forge/ucx-split-feedstock/pull/111, we should have a new migration (it's needed to re-enable ucx support e.g. in arrow).

CC @conda-forge/ucx-split @kkraus14 @pentschev