### PR TITLE
Close out migration for mimalloc209

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -560,7 +560,7 @@ lzo:
 metis:
   - 5.1
 mimalloc:
-  - 2.0.7
+  - 2.0.9
 mkl:
   - 2022
 mkl_devel:

--- a/recipe/migrations/mimalloc209.yaml
+++ b/recipe/migrations/mimalloc209.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1676260893.401095
-mimalloc:
-- 2.0.9


### PR DESCRIPTION
There was only one migration PR the bot would have opened, but [the bot has issues with it]( https://github.com/regro/cf-scripts/actions/runs/4500691380/jobs/7920148273#step:8:11584 ). Manually created this PR ( https://github.com/conda-forge/hpx-feedstock/pull/12 ). While more work is likely needed there, this migration can be closed out.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
