### PR TITLE
Add `libcufft` to arch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -547,6 +547,8 @@ cuda-cccl-impl
 cuquantum
 cuquantum-python
 cusparselt
+libcublas
+libcufft
 libcusolver
 libcusparse
 libnvjitlink
@@ -696,6 +698,3 @@ lammps
 phonopy
 pyscal
 pygplates
-libcublas
-libcublas-dev
-libcublas-static


### PR DESCRIPTION
Also move `libcublas` next to `libcufft` and drop unneeded items.

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4306

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
