### PR TITLE
Stop curl 8 migration after repodata patch

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -313,7 +313,7 @@ console_bridge:
 cutensor:
   - 1
 curl:
-  - 7
+  - 8
 davix:
   - '0.8'
 dbus:
@@ -448,7 +448,7 @@ libblitz:
 libcint:
   - '5.2'
 libcurl:
-  - 7
+  - 8
 libcrc32c:
   - 1.1
 libdap4:

--- a/recipe/migrations/curl8.yaml
+++ b/recipe/migrations/curl8.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-curl:
-- '8'
-migrator_ts: 1679327080.7742326


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
See https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/434#event-8997305908