### PR TITLE
Add osx_arm64 support for ncbi-datasets-cli

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1232,3 +1232,4 @@ webrtcvad
 hnswlib
 pyebsdindex
 libmongocxx
+ncbi-datasets-cli


### PR DESCRIPTION
I noticed the `build.py` script in `ncbi-datasets-cli` already downloads an `universal` macOS binary, and in [PR #180](https://github.com/conda-forge/ncbi-datasets-cli-feedstock/pull/180) I changed some fields in the `conda-forge.yml` to add `osx_arm64` platform support.

Opening this PR to do it using the official way, thru a migration, as mentioned in the gitter channel.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)