### PR TITLE
Remove CMAKE_GENERATOR and win cleanup

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,3 @@
-# This differs from target_platform in that it determines what subdir the compiler
-#    will target, not what subdir the compiler package will be itself.
-#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
-#    code on win-64 miniconda.
-cross_compiler_target_platform:  # [win]
-  - win-64                     # [win]
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
@@ -46,8 +40,6 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
-CMAKE_GENERATOR:               # [win]
-  - NMake Makefiles            # [win]
 
 cuda_compiler:                 # [linux or win]
   - nvcc                       # [linux or win]
@@ -114,8 +106,6 @@ macos_machine:                 # [osx]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 11.0                       # [osx and arm64]
   - 10.9                       # [osx and x86_64]
-target_platform:               # [win]
-  - win-64                     # [win]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:


### PR DESCRIPTION
CMAKE_GENERATOR was added as a workaround for some azure issue which is gone now.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

cc @bluescarni 
