### PR TITLE
Use OpenSSL 3.0.x for global pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -606,7 +606,7 @@ openjpeg:
 openmpi:
   - 4
 openssl:
-  - '3'
+  - '3.0'
 openturns:
   - '1.20'
 orc:


### PR DESCRIPTION
@conda-forge/core @conda-forge/openssl What do you think about having `3.0.x` in the gloabl pinning for `openssl`?

Since OpenSSL 3.0 they're now following semantic versioning for the ABI however `3.0.x` is a LTS series that continues to recieve patch releases in addition to the `3.1.x` series.

For context, I've seen some issues with OpenSSL 3.1.0 that require a new OpenSSL release but that likely won't happen for a couple of months which leaves me a bit stuck (unless we're willing to pick up patches from upstream in the openssl feedstock). I don't think there is any real downside to using the LTS series in the global pinning and maximising compatibility.