### PR TITLE
Add migration for r-base 4.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -678,7 +678,8 @@ root_base:
 ruby:
   - 2.5
   - 2.6
-r_base:   # [not win]
+r_base:
+  - 4.1   # [win]
   - 4.2   # [not win]
 scotch:
   - 6.0.9

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -678,8 +678,7 @@ root_base:
 ruby:
   - 2.5
   - 2.6
-r_base:
-  - 4.1
+r_base:   # [not win]
   - 4.2   # [not win]
 scotch:
   - 6.0.9

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -11,7 +11,7 @@ __migrator:
   include_noarch: True
   pr_limit: 4
   conda_forge_yml_patches:
-    build_platform.win_64: win_disabled
+    provider.win_64: win_disabled
 
 r_base:
   - 4.3   # [not win]

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -11,5 +11,5 @@ __migrator:
   include_noarch: True
   pr_limit: 4
 
-r_base:   # [not win]
+r_base:
   - 4.3   # [not win]

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -10,6 +10,8 @@ __migrator:
   longterm: True
   include_noarch: True
   pr_limit: 4
+  conda_forge_yml_patches:
+    build_platform.win_64: win_disabled
 
 r_base:
   - 4.3   # [not win]

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -9,7 +9,7 @@ __migrator:
   automerge: True
   longterm: True
   include_noarch: True
-  pr_limit: 40
+  pr_limit: 4
 
 r_base:   # [not win]
   - 4.3   # [not win]

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1682187595
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+r_base:   # [not win]
+  - 4.3   # [not win]

--- a/recipe/migrations/r-base43.yaml
+++ b/recipe/migrations/r-base43.yaml
@@ -3,6 +3,13 @@ __migrator:
   kind: version
   migration_number: 1
   bump_number: 1
+  operation: key_add
+  commit_message: "Rebuild for r-base 4.3"
+  primary_key: r_base
+  automerge: True
+  longterm: True
+  include_noarch: True
+  pr_limit: 40
 
 r_base:   # [not win]
   - 4.3   # [not win]


### PR DESCRIPTION
Note that the previous r-base migration included the following lines (I've adjusted the commit message to be appropriate here):

```
  operation: key_add
  commit_message: "Rebuild for r-base 4.3"
  primary_key: r_base
  automerge: True
  longterm: True
  include_noarch: True
  pr_limit: 40
```

I don't see enough in the documentation to determine if that's needed here as well.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
