### PR TITLE
add opentelemetry to pinning

### DIFF
--- a/recipe/migrations/libopentelemetry_cpp19.yaml
+++ b/recipe/migrations/libopentelemetry_cpp19.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libopentelemetry_cpp:
+- 1.9
+migrator_ts: 1683274179.5563672


### PR DESCRIPTION
Following https://github.com/conda-forge/cpp-opentelemetry-sdk-feedstock/issues/38, we're now ready to add it to the pinning & use it in feedstocks (like arrow).