### PR TITLE
Add datalad to osx_arm64 migrations

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1259,3 +1259,4 @@ json_schema_validator
 hole2
 namaster
 rattler-build
+datalad


### PR DESCRIPTION
datalad itself is pure python package without binary extensions but IIRC we have it without `noarch: python` which originally was removed in https://github.com/conda-forge/datalad-feedstock/commit/170c8520b69fb5ae1ac86039f2383cef61235270 to resolve some python 2.7 issue apparently.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
