### PR TITLE
Remove nodejs=14 from the pinning as it is EOL

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -588,7 +588,6 @@ nettle:
 nodejs:
   - '18'
   - '16'
-  - '14'  # [not (osx and arm64)]
 nss:
   - 3
 nspr:


### PR DESCRIPTION
Fixes #4470 