### PR TITLE
migrate libprotobuf 4.23 & grpc 1.55 (additionally to existing pins)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -172,6 +172,10 @@ zip_keys:
   -
     - arrow_cpp
     - libarrow
+  # until libprotobuf 3.21->4.23 migration is complete
+  -
+    - libgrpc
+    - libprotobuf
 
 
 # aarch64 specifics because conda-build sets many things to centos 6

--- a/recipe/migrations/protobuf423.yaml
+++ b/recipe/migrations/protobuf423.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libgrpc:
+- '1.54'
+- '1.55'
+libprotobuf:
+- '3.21'
+- '4.23'
+migrator_ts: 1684932016.2362208


### PR DESCRIPTION
Main discussion for this happened in #4075.

The situation:
* protobuf has a new version scheme where, the middle number is the feature level, and the "major" version corresponds to the language bindings -- e.g. v21.12 == v3.21.21 (C++) == v4.21.12 (python)
* the short-lived 22-series bumped the major version for C++ and also introduced a dependence on abseil, not just internally, but in the API. This will become [painful](https://github.com/conda-forge/abseil-cpp-feedstock/issues/45) later, but not now at least
* not only does it depend on abseil, but also abseil's test targets, which didn't compile yet with shared builds on windows and thus took a [while](https://github.com/conda-forge/abseil-cpp-feedstock/pull/58)
* libgrpc 1.55 is [apparently](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075#issuecomment-1546655409) _only_ compatible with protobuf 4.23, hence the zip-keys here

Due to the potential fall-out from the major version bump, I'm suggesting to do a dual protobuf pin (see also https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4068). This is fortuitous timing, because we've just completed a long-standing grpc-[refactor](https://github.com/conda-forge/grpc-cpp-feedstock/pull/243) as well (adding shared libs on windows, removing some run-exports for private libs), which will ease digesting that.

Closes #4068 
Closes #4075 
Closes #4436 
Closes #4454
