### PR TITLE
Add pin for libosqp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -502,6 +502,8 @@ libnetcdf:
   - 4.8.1
 libopencv:
   - 4.7.0
+libosqp:
+  - 0.6.3
 libpcap:
   - '1.10'
 libpng:


### PR DESCRIPTION
This PR adds a pin for libosqp, that has been stuck to release 0.6.2 for a long time, and recently saw a release 0.6.3 and soon will also get a 1.0.0 release. As 0.6.2 has been around a long time, I think we can avoid to have a migrator for 0.6.2, and just do the 0.6.3 migration.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
