### PR TITLE
pin protobuf to patch level & restart protobuf423 migration

### DIFF
--- a/recipe/migrations/protobuf423.yaml
+++ b/recipe/migrations/protobuf423.yaml
@@ -1,11 +1,11 @@
 __migrator:
   build_number: 1
   kind: version
-  migration_number: 1
+  migration_number: 2
 libgrpc:
 - '1.54'
 - '1.55'
 libprotobuf:
 - '3.21'
-- '4.23'
+- '4.23.2'
 migrator_ts: 1684932016.2362208


### PR DESCRIPTION
See #4075. grpc now depends also on the patch version of protobuf to run correctly, so we need to reflect that, or things break.

Restarting the migration is I think the least intrusive change, because otherwise we'd need to mark libprotobuf 4.23.2 as broken, and/or start repo-patching.

requires:
* [x] https://github.com/conda-forge/libprotobuf-feedstock/pull/160
* [x] https://github.com/conda-forge/grpc-cpp-feedstock/pull/300
* [x] https://github.com/conda-forge/protobuf-feedstock/pull/189


