### PR TITLE
Turn off `check_solvable` in CUDA 12 migrator

### DIFF
--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -10,6 +10,7 @@ __migrator:
   override_cbc_keys:
     - cuda_compiler_stub
   operation: key_add
+  check_solvable: false
   primary_key: cuda_compiler_version
   ordering:
     cxx_compiler_version:


### PR DESCRIPTION
Usually [`check_solvable` is set to `false` in other CUDA migrators]( https://github.com/search?q=repo%3Aconda-forge%2Fconda-forge-pinning-feedstock%20check_solvable&type=code ), this was missed in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4400 ). Adding it here.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
