### PR TITLE
Skip CUDA 12 Windows (for now)

### DIFF
--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -47,11 +47,11 @@ __migrator:
       - 12.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   commit_message: "Rebuild for CUDA 12"
 
-cuda_compiler:                 # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cuda-nvcc                  # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-cuda_compiler_version:         # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 12.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler_version:         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12.0                       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_compiler_version:            # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
@@ -62,8 +62,8 @@ cxx_compiler_version:          # [linux64 and os.environ.get("CF_CUDA_ENABLED", 
 fortran_compiler_version:      # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-cudnn:                         # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cudnn:                         # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 8                          # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 cdt_name:                      # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cos7                       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Fixes https://github.com/regro/cf-scripts/issues/1698

As there are still some things to sort out for CUDA 12 Windows support, limit the CUDA 12 addition here to Linux.

cc @beckermr

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
