### PR TITLE
Add message to maintainers about CUDA 12 transition

### DIFF
--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -45,14 +45,14 @@ __migrator:
       - 11.1                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
       - 11.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
       - 12.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  commit_message: | Rebuild for CUDA 12
-
-The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
-build tools. Notably, the cudatoolkit package no longer exists, and packages
-should depend directly on the specific cuda libraries (libblas, libcusolver,
-etc) as needed. A list of all new cuda packages and their status is available
-[in this issue](https://github.com/conda-forge/staged-recipes/issues/21382).
-
+  commit_message: |
+    Rebuild for CUDA 12
+    
+    The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
+    build tools. Notably, the cudatoolkit package no longer exists, and packages
+    should depend directly on the specific cuda libraries (libblas, libcusolver,
+    etc) as needed. A list of all new cuda packages and their status is available
+    [in this issue]( https://github.com/conda-forge/staged-recipes/issues/21382 ).
 
 cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -5,7 +5,7 @@ __migrator:
   migration_number:
     1
   build_number:
-    1
+    2
   paused: false
   override_cbc_keys:
     - cuda_compiler_stub

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -5,7 +5,7 @@ __migrator:
   migration_number:
     1
   build_number:
-    2
+    1
   paused: false
   override_cbc_keys:
     - cuda_compiler_stub
@@ -53,6 +53,7 @@ __migrator:
     should depend directly on the specific CUDA libraries (libblas, libcusolver,
     etc) as needed. For an in-depth overview of the changes and to report problems
     [see this issue]( https://github.com/conda-forge/conda-forge.github.io/issues/1963 ).
+    Please feel free to raise any issues encountered there. Thank you! :pray:
 
 cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -45,7 +45,14 @@ __migrator:
       - 11.1                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
       - 11.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
       - 12.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  commit_message: "Rebuild for CUDA 12"
+  commit_message: | Rebuild for CUDA 12
+
+The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
+build tools. Notably, the cudatoolkit package no longer exists, and packages
+should depend directly on the specific cuda libraries (libblas, libcusolver,
+etc) as needed. A list of all new cuda packages and their status is available
+[in this issue](https://github.com/conda-forge/staged-recipes/issues/21382).
+
 
 cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -50,8 +50,8 @@ __migrator:
     
     The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
     build tools. Notably, the cudatoolkit package no longer exists, and packages
-    should depend directly on the specific cuda libraries (libblas, libcusolver,
-    etc) as needed. A list of all new cuda packages and their status is available
+    should depend directly on the specific CUDA libraries (libblas, libcusolver,
+    etc) as needed. A list of all new CUDA packages and their status is available
     [in this issue]( https://github.com/conda-forge/staged-recipes/issues/21382 ).
 
 cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -51,8 +51,8 @@ __migrator:
     The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
     build tools. Notably, the cudatoolkit package no longer exists, and packages
     should depend directly on the specific CUDA libraries (libblas, libcusolver,
-    etc) as needed. A list of all new CUDA packages and their status is available
-    [in this issue]( https://github.com/conda-forge/staged-recipes/issues/21382 ).
+    etc) as needed. For an in-depth overview of the changes and to report problems
+    [see this issue]( https://github.com/conda-forge/conda-forge.github.io/issues/1963 ).
 
 cuda_compiler:                 # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cuda-nvcc                  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
The purpose of this PR is to add more context to automigrations for CUDA 12 because the transition is more involved than just swapping out the compiler version.

Ideally, these notes would be added to the PR header, but I didn't see a key for that in the migration YAML. Maybe there is one that I don't know about?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
