### PR TITLE
add depfinder

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1281,3 +1281,4 @@ r-rsvg
 gpaw
 r-infotheo
 r-magick
+depfinder


### PR DESCRIPTION
Add `depfinder` to the migrator.

Closes https://github.com/conda-forge/depfinder-feedstock/issues/40