### PR TITLE
add migrator for lmdb

### DIFF
--- a/recipe/migrations/lmdb0929.yaml
+++ b/recipe/migrations/lmdb0929.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+lmdb:
+- 0.9.29
+migrator_ts: 1685659125.240795


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/lmdb-feedstock/pull/22, resp. https://github.com/conda-forge/lmdb-feedstock/pull/24. It appears in a couple of places and should be part of the global pinning.

CC @conda-forge/lmdb