### PR TITLE
Add pybuilder to list

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1290,3 +1290,4 @@ mo_pack
 sshpass
 spleaf
 kepderiv
+pybuilder


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Missing pybuilder osx-arm64 versions
<!--
Please add any other relevant info below:
-->
0.11 can already be installed through noarch, but 0.13 (compat with python>3.6) cannot.