### PR TITLE
Soft close ffmpeg 6 migration stopping the dual builds

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -333,7 +333,7 @@ exiv2:
 expat:
   - 2
 ffmpeg:
-  - '5'
+  - '6'
 fftw:
   - 3
 flann:

--- a/recipe/migrations/ffmpeg6.yaml
+++ b/recipe/migrations/ffmpeg6.yaml
@@ -3,6 +3,5 @@ __migrator:
   kind: version
   migration_number: 1
 ffmpeg:
-- '5'
 - '6'
 migrator_ts: 1684252387.6420875


### PR DESCRIPTION
I've checked that the remaining feedstocks fore the FFMPEG migration are the same ones that were remaining for the ffmpeg 5 migration. They all seem to need upstream changes and many of the feedstocks seem to be abandoned.


@h-vetinari @conda-forge/opencv this should help avoid the huge build matrix in https://github.com/conda-forge/opencv-feedstock/pull/363#issuecomment-1608672751


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
