### PR TITLE
loosen libarrow pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -246,7 +246,7 @@ arpack:
   - 3.7
 # keep in sync with libarrow
 arrow_cpp:
-  - 12.0.0
+  - 12
   - 11.0.0
   - 10.0.1
   - 9.0.0
@@ -441,7 +441,7 @@ libarchive:
 # keep in sync with arrow_cpp (libarrow exists only from 10.x,
 # but make sure we have same length for zip as arrow_cpp)
 libarrow:
-  - 12.0.0
+  - 12
   - 11.0.0
   - 10.0.1
   - 9.0.0


### PR DESCRIPTION
Following https://github.com/conda-forge/arrow-cpp-feedstock/issues/1096 & https://github.com/conda-forge/arrow-cpp-feedstock/pull/1087

We could backport this to other maintained arrow versions, but since those won't receive new patch versions, that's not going to change anything.