### PR TITLE
update comment about grpc_cpp vs. libgrpc

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -393,7 +393,8 @@ googleapis_cpp:
   - '0.10'
 graphviz:
   - '8'
-# keep in sync with libgrpc
+# this has been renamed to libgrpc as of 1.49; dropped as of 1.52.
+# IOW, this version is unavailable; makes the renaming more obvious
 grpc_cpp:
   - '1.52'
 harfbuzz:


### PR DESCRIPTION
Noticed by @Tobias-Fischer, see [here](https://github.com/conda-forge/tensorflow-feedstock/pull/323#discussion_r1247728124).

The output `grpc-cpp` has been dropped as of https://github.com/conda-forge/grpc-cpp-feedstock/pull/266.