### PR TITLE
Relax pin for wcslib to match run_export

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -771,7 +771,7 @@ volk:
 vtk:
   - 9.2.5
 wcslib:
-  - '7.7'
+  - '7'
 wxwidgets:
   - '3.2'
 x264:


### PR DESCRIPTION
run export only pins to 'x'
https://github.com/conda-forge/wcslib-feedstock/blob/main/recipe/meta.yaml#L21

Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4626

CC: @hugobuddel

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
