### PR TITLE
Add flatbuffers pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -338,6 +338,8 @@ fftw:
   - 3
 flann:
   - 1.9.1
+flatbuffers:
+  - 23.5.26
 fmt:
   - '9'
 fontconfig:


### PR DESCRIPTION
This was omitted from https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4568

cc @h-vetinari @hmaarrfk 