### PR TITLE
Add libpnetcdf to osx-arm64 and aarch migrators

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -754,3 +754,4 @@ r-odbc
 r-splines2
 gnupg
 cwinpy
+libpnetcdf

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1309,3 +1309,4 @@ batoid-rubin
 dftd3-python
 pylops
 pysolid
+libpnetcdf


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This adds libpnetcdf to the migrators.
