### PR TITLE
Mark the CUDA arch migrators long-term

### DIFF
--- a/recipe/migrations/cuda120_ppc64le_aarch64.yaml
+++ b/recipe/migrations/cuda120_ppc64le_aarch64.yaml
@@ -8,6 +8,7 @@ __migrator:
     1
   # Pausing to start on CUDA 12.0 `x86_64` migrator first
   paused: true
+  longterm: true
   override_cbc_keys:
     - cuda_compiler_stub
   operation: key_add

--- a/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
+++ b/recipe/migrations/cuda_112_ppc64le_aarch64.yaml
@@ -7,6 +7,7 @@ __migrator:
   build_number:
     1
   paused: false
+  longterm: true
   override_cbc_keys:
     - cuda_compiler_stub
   operation: key_add


### PR DESCRIPTION
As the CUDA arch migrators build off the arch migrator, which is marked as long-term, mark the CUDA arch migrators as long-term too.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
