### PR TITLE
photochem osx arm

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1324,3 +1324,4 @@ pyddx
 quantized-mesh-encoder
 pymartini
 pydelatin
+photochem


### PR DESCRIPTION
Adding `osx-arm` build for the `photochem` package (https://github.com/conda-forge/photochem-feedstock)
