### PR TITLE
Add pytensor-suite to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -726,6 +726,7 @@ r-marginaleffects
 conda-ecosystem-user-package-isolation
 sparsehash
 graph-tool
+pytensor-suite
 kim-api
 mlip
 n2p2


### PR DESCRIPTION
This is for a multi-output feedstock. I assume that I add the name of the feedstock to the migration, not the names of the individual outputs (`pytensor` and `pytensor-base`).