### PR TITLE
Bump `netcdf-fortran` pin to 4.6

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -562,7 +562,7 @@ ncurses:
 netcdf_cxx4:
   - 4.3
 netcdf_fortran:
-  - 4.5
+  - 4.6
 nettle:
   - '3.8'
 nodejs:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

It looks like the current pins are trying to restrict to `netcdf-fortran =4.5` and `libnetcdf =4.9.2`, but `netcdf-fortran =4.5` looks like it is itself [restricted to `libnetcdf =4.8`](https://anaconda.org/conda-forge/netcdf-fortran/files?page=2) leading to [unresolvable environments](https://github.com/conda-forge/staged-recipes/pull/23435#issuecomment-1646185849).

It looks like a [migration to `4.6`](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3185) was merged but the pin was never bumped. @xylar @ocefpaf was this intentional?

Apologies if I misunderstood anything, and please feel free to close this PR if so!
