### PR TITLE
drop numpy 1.21 per NEP29

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -577,6 +577,7 @@ nlopt:
 ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
+# we follow NEP29 in choosing the oldest version possible
 numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.22

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -577,7 +577,7 @@ nlopt:
 ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
-# we follow NEP29 in choosing the oldest version possible
+# we roughly follow NEP29 in choosing the oldest version
 numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.22

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -579,9 +579,9 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.21
-  - 1.21
-  - 1.21
+  - 1.22
+  - 1.22
+  - 1.22
 occt:
   - '7.7'
 openblas:

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -36,8 +36,8 @@ python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.21               # [not (osx and arm64)]
-  - 1.21               # [not (osx and arm64)]
+  - 1.22               # [not (osx and arm64)]
+  - 1.22               # [not (osx and arm64)]
 python_impl:
   - pypy               # [not (osx and arm64)]
   - pypy               # [not (osx and arm64)]


### PR DESCRIPTION
Following @h-vetinari in #4214
> It's [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) time again, which says

> > On Jan 31, 2023 drop support for NumPy 1.20 (initially released on Jan 31, 2021)
Previous PRs along these lines: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3420 https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2600


NEP29: https://numpy.org/neps/nep-0029-deprecation_policy.html

> On Jun 23, 2023 drop support for NumPy 1.21 (initially released on Jun 22, 2021)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
