### PR TITLE
Add r-filelock to arch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -172,6 +172,7 @@ r-survival
 r-essentials
 r-recommended
 r-tidyverse
+r-filelock
 r-forecast
 r-bitops
 r-git2r


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.



I needed to build `bioconductor-biocfilecache` on Linux aarch64 but currently it fails with the following error:
```
12:31:19 BIOCONDA INFO (OUT)   File "/opt/conda/lib/python3.8/site-packages/boa/cli/mambabuild.py", line 133, in mamba_get_install_actions
12:31:19 BIOCONDA INFO (OUT)     raise err
12:31:19 BIOCONDA INFO (OUT) conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-aarch64: {MatchSpec("r-filelock")}
12:31:20 BIOCONDA ERROR COMMAND FAILED (exited with 1): docker run -t --net host --rm -v /tmp/tmpn776261y/build_script.bash:/opt/build_script.bash -v /home/mgrigorov/miniconda3/envs/biotest/conda-bld/:/opt/host-conda-bld -v /home/mgrigorov/git/bioconda/bioconda-recipes/recipes/bioconductor-biocfilecache:/opt/recipe -e LC_ADDRESS=en_US.UTF-8 -e LC_NAME=en_US.UTF-8 -e LC_MONETARY=en_US.UTF-8 -e LC_PAPER=en_US.UTF-8 -e LANG=en_US.UTF-8 -e LC_IDENTIFICATION=en_US.UTF-8 -e LC_TELEPHONE=en_US.UTF-8 -e LC_MEASUREMENT=en_US.UTF-8 -e LC_TIME=en_US.UTF-8 -e LC_NUMERIC=en_US.UTF-8 -e HOST_USER_ID=1000 ghcr.io/yikun/bioconda-utils-build-env-cos7-aarch64 /bin/bash /opt/build_script.bash

12:31:20 BIOCONDA ERROR BUILD FAILED recipes/bioconductor-biocfilecache
12:31:20 BIOCONDA INFO (COMMAND) conda build purge
12:31:21 BIOCONDA ERROR BUILD SUMMARY: of 1 recipes, 1 failed and 0 were skipped. Details of recipes and environments follow.
12:31:21 BIOCONDA ERROR BUILD SUMMARY: FAILED recipe recipes/bioconductor-biocfilecache
```

I hope that with the proposed modifications in this PR `r-filelock` will be usable on Linux aarch64.

Initially I created https://github.com/conda-forge/r-filelock-feedstock/pull/8 but @mfansler kindly explained to me that the proper way is to add `r-filelock` to the pinning-feedstock 
