### PR TITLE
add psy-reg for OSX ARM migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1339,3 +1339,4 @@ gdma
 ambit
 ncrystal
 mcpl
+psy-reg


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Seems to be the last dependency for `esmvaltool` package which is not osx-arm64 ready.