### PR TITLE
Close out five Poppler migrations.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -629,7 +629,7 @@ pixman:
 poco:
   - 1.12.4
 poppler:
-  - '22.12'
+  - '23.07'
 postgresql:
   - 15
 postgresql_plpython:

--- a/recipe/migrations/poppler2301.yaml
+++ b/recipe/migrations/poppler2301.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1674060515.3542438
-poppler:
-- '23.01'

--- a/recipe/migrations/poppler2303.yaml
+++ b/recipe/migrations/poppler2303.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1677871843.837234
-poppler:
-- '23.03'

--- a/recipe/migrations/poppler2304.yaml
+++ b/recipe/migrations/poppler2304.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1680651753.1573474
-poppler:
-- '23.04'

--- a/recipe/migrations/poppler2305.yaml
+++ b/recipe/migrations/poppler2305.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1683564914.7870126
-poppler:
-- '23.05'

--- a/recipe/migrations/poppler2307.yaml
+++ b/recipe/migrations/poppler2307.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1688687037.4481394
-poppler:
-- '23.07'


### PR DESCRIPTION
These have largely been stuck on `kfilemetadata`, which is super out-of-date and does not appear likely to get updated any time soon. I also just finished up https://github.com/conda-forge/gimagereader-qt-feedstock/pull/15 , which is actually maintainable but also needed some work (leptonica → tesseract → gimagereader-qt).