### PR TITLE
Add r-igraph to arch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -215,6 +215,7 @@ r-sp
 r-reticulate
 r-dimred
 r-arules
+r-igraph
 r-network
 r-spam
 r-ade4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

l needed to build `bioconductor-geneplast` `bioconductor-fgnet` on Linux aarch 64 but currently it fails with the following error:
`
-nothing provides requested r-igraph
`

l hope that with the proposed modifications in this PR r-igraphwill be usable on Linux aarch64.

