### PR TITLE
Add r-ape,r-tkrplot,r-locfit,r-mixtools,r-pbmcapply,r-minpack.lm,r-blockmodeling,r-amap,r-princurve to arch migration

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -212,6 +212,15 @@ r-fracdiff
 r-rodbc
 r-rjson
 r-sp
+r-ape
+r-tkrplot
+r-locfit
+r-mixtools
+r-pbmcapply
+r-minpack.lm
+r-blockmodeling
+r-amap
+r-princurve
 r-reticulate
 r-dimred
 r-arules


### PR DESCRIPTION
Add r-ape,r-tkrplot,r-locfit,r-mixtools,r-pbmcapply,r-minpack.lm,r-blockmodeling,r-amap,r-princurve to arch migration

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-ape, bioconfuctor-geneplast, bioconductor-treeio, bioconfuctor-genarise, bioconfuctor-gemini, bioconductor-diffgeneanalysis, bioconductor-ebseq, bioconductor-ctc, bioconductor-clusterdignificance` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-ape, bioconductor-ape and bioconductor-ape  
             -nothing provides requested r-ape

bioconfuctor-geneplast
              -nothing provides requested r-tkrplot

bioconfuctor-genarise
              -nothing provides requested r-locfit

bioconfuctor-gemini
              -nothing provides requested r-mixtools
               -nothing provides requestedr-pbmcapply

bioconductor-diffgeneanalysis
              -nothing provides requested r-minpack.lm

bioconductor-ebseq
              -nothing provides requested r-blockmodeling

bioconductor-ctc
              -nothing provides requested r-amap
bioconductor-clusterdignificance

              -nothing provides requested r-princurve

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 
