### PR TITLE
Add  r-vegan,r-rmysql,r-ggrepel,r-sm,r-infotheo,r-delaporte

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -236,6 +236,12 @@ r-gdtools
 r-proxy
 r-nnls
 r-lhs
+r-vegan
+r-rmysql
+r-ggrepel
+r-sm
+r-infotheo
+r-delaporte
 r-multicool
 r-rconv
 r-bbmisc


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-gpa, bioconfuctor-gladiatox, bioconductor-judge, bioconfuctor-clustergenarise, bioconfuctor-clustercomp, bioconductor-chicago` on Linux aarch64 but currently they fail with the following error:
```
`bioconductor-gpa  
             -nothing provides requested r-vegan
             -nothing provides requested r-ggrepel

bioconfuctor-gladiatox
              -nothing provides requested r-vegan
              -nothing provides requested r-rmysql

bioconductor-clusterjudge
              -nothing provides requested r-infotheo

bioconfuctor-clustercomp
              -nothing provides requested r-sm

 bioconductor-chicago
              -nothing provides requested r-delaporte

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 
