### PR TITLE
Add spdlog=1.12 to fmt10 migrator

### DIFF
--- a/recipe/migrations/fmt10.yaml
+++ b/recipe/migrations/fmt10.yaml
@@ -4,4 +4,6 @@ __migrator:
   migration_number: 1
 fmt:
 - '10'
+spdlog:
+- '1.12'
 migrator_ts: 1683802784.4940007


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4667 for the rationale. In a nutshell, many fmt10 migrations are blocked as they also depend on spdlog, but spdlog=1.11 (the pinned version) was never built with fmt10 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
