### PR TITLE
Add r-gamlss,r-vgam,r-pscl,r-bbmle,r-rtsne,r-apcluster,r-fpc,r-wgcna,…

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -190,6 +190,15 @@ r-ccapp
 r-fastcluster
 r-ddalpha
 r-xml
+r-gamlss
+r-vgam
+r-pscl
+r-bbmle
+r-rtsne
+r-apcluster
+r-fpc
+r-wgcna
+r-rcpphnsw
 r-catools
 r-geometry
 r-rcppeigen


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-desingle, bioconfuctor-linnorm, bioconductor-moda, bioconfuctor-biocneighbors` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-desingle  
             -nothing provides requested r-gamlss
             -nothing provides requested r-vgam
             -nothing provides requested r-pscl
             -nothing provides r-base >= 3.5.1,3.5.2.0a0 needed by r-bbmle-1.0.19-r351_1001

bioconfuctor-linnorm,
              -nothing provides requested r-mclust
              -nothing provides requested r-rtsne
              -nothing provides requested r-apcluster
              -nothing provides requested r-fastcluster
	      -nothing rpovides requested r-base >= 3.5.1,<3.5.2.0a0 needed by r-fpc


bioconfuctor-moda
              -nothing provides requested r-wgcna


bioconfuctor-biocneighbors
              -nothing provides requested r-rcoohnsw
```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 