### PR TITLE
Add mysql-connector-cpp to arch_rebuild

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -401,6 +401,7 @@ libignition-physics
 libignition-transport4
 viztracer
 memray
+mysql-connector-cpp
 mysql-connector-odbc
 msgspec
 openai


### PR DESCRIPTION

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


I need an `linux-aarch64` package for mysql-connector-cpp. 
Related-to: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4753

`r-rmysql` is phased out (https://github.com/r-dbi/RMySQL) so there is no much hope that it will support OpenSSL 3.x and this is a blocker for its `aarch64` build - https://github.com/conda-forge/r-rmysql-feedstock/pull/20
The final goal is to provide a  `r-rmariadb` `linux-aarch64` package that will use `mysql-connector-cpp` instead.