### PR TITLE
Add mariadb-connector-c to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -427,6 +427,7 @@ libignition-physics
 libignition-transport4
 viztracer
 memray
+mariadb-connector-c
 mysql-connector-cpp
 mysql-connector-odbc
 msgspec


### PR DESCRIPTION
For `linux-aarch64` support

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

[RMySQL](https://github.com/r-dbi/RMySQL) is being phased out in favor of the new [RMariaDB](https://github.com/r-dbi/RMariaDB) package. And RMariaDB uses either `mysql-connector-c` or `mariadb-connector-c`. We need a `linux-aarch64` build of the latter.