### PR TITLE
Add r-rfast, r-dplr,r-kohonen to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -239,6 +239,8 @@ r-sp
 r-pdist
 r-robust
 r-logistf
+r-rfast
+r-dplr
 r-changepoint
 r-idpmisc
 r-rrcov

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -240,6 +240,7 @@ r-pdist
 r-robust
 r-logistf
 r-rfast
+r-kohonen
 r-dplr
 r-changepoint
 r-idpmisc


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-annotationfilter, bioconductor-cogena, bioconfuctor-gcsscore` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-annotationfilter
             -nothing provides requested r-rfast

bioconfuctor-cogena
              -nothing provides requested r-kohonento

bioconfuctor-gcsscore
              -nothing provides requested r-dplr
```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 