### PR TITLE
Add r-rcppnumerical, r-fdrtool, r-factominer, r-compositions to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -202,6 +202,10 @@ r-apcluster
 r-fpc
 r-wgcna
 r-rcpphnsw
+r-rcppnumerical
+r-fdrtool
+r-factominer
+r-compositions
 r-catools
 r-geometry
 r-rcppeigen


### PR DESCRIPTION


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-apeglm, bioconductor-dep, bioconfuctor-microbiome` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-apeglm
             -nothing provides requested r-rcppnumerical

bioconfuctor-dep
              -nothing provides requested r-fdrtool

bioconfuctor-genegeneinter
              -nothing provides requested r-factominer

bioconfuctor-microbiome
              -nothing provides requested r-compositions
```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 
