### PR TITLE
add r-gwasexacthw, r-ggfoce, r-restfulr to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -259,6 +259,9 @@ r-flexclust
 r-sgeostat
 r-maldiquant
 r-drc
+r-gwasexacthw
+r-ggfoce
+r-restfulr
 r-irlba
 r-rann
 r-ddrtree


### PR DESCRIPTION

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-gwastools, bioconfuctor-flowsom` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-gwastools
             -nothing provides requested r-gwasexacthw

bioconfuctor-flowsom
              -nothing provides requested r-ggfoce

bioconfuctor-rtracklayer
              -nothing provides requested r-restfulr

bioconfuctor-flowclean
              -nothing provides requested r-changepoint
```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 