### PR TITLE
migrate libabseil, libgrpc & libprotobuf

### DIFF
--- a/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
+++ b/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libabseil:
+- 20230802
+libgrpc:
+- "1.57"
+libprotobuf:
+- 4.23.4
+migrator_ts: 1692632590.658328

--- a/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
+++ b/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
@@ -8,4 +8,6 @@ libgrpc:
 - "1.57"
 libprotobuf:
 - 4.23.4
+MACOSX_DEPLOYMENT_TARGET:
+- "10.13"
 migrator_ts: 1692632590.658328

--- a/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
+++ b/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
@@ -8,6 +8,6 @@ libgrpc:
 - "1.57"
 libprotobuf:
 - 4.23.4
-MACOSX_DEPLOYMENT_TARGET:
-- "10.13"
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- "10.13"                  # [osx and x86_64]
 migrator_ts: 1692632590.658328


### PR DESCRIPTION
Follows plan in #4075; currently on hold until we move to MacOS 10.13, because abseil requires it, and affects a lot of packages.