### PR TITLE
Add r-timsac, r-ggforce, r-fbasics, r-dqrng, r-ps, r-tm, r-coin, r-co…

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -260,7 +260,15 @@ r-sgeostat
 r-maldiquant
 r-drc
 r-gwasexacthw
-r-ggfoce
+r-ggforce
+r-timsac
+r-fbasics
+r-dqrng
+r-ps
+r-tm
+r-coin
+r-compquadform
+r-pander
 r-restfulr
 r-irlba
 r-rann


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconfuctor-flowsom, bioconfuctor-chipseq, bioconfuctor-scran, bioconfuctor-ctrap, bioconfuctor-genextender, bioconfuctor-hipathia, bioconfuctor-goprofiles, bioconfuctor-metab` on Linux aarch64 but currently they fail with the following error:
```
bioconfuctor-flowsom
              -nothing provides requested r-ggforce
(there is no  `r-ggfoce`, `r-ggfoce` is a misspelling, it's supposed to be [r-ggforce](https://github.com/conda-forge/r-ggforce-feedstock))
bioconfuctor-chipseq
              -nothing provides requested r-timsac
              -nothing provides requested r-fbasics

bioconfuctor-scran
              -nothing provides requested r-dqrng

bioconfuctor-ctrap
              -nothing provides requested r-ps

bioconfuctor-genextender
              -nothing provides requested r-tm

bioconfuctor-hipathia
              -nothing provides requested r-coin

bioconfuctor-goprofiles
              -nothing provides requested r-compquadform

bioconfuctor-metab
              -nothing provides requested r-pander
```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 