### PR TITLE
Add r-tweenr, r-rmixmod to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -35,6 +35,8 @@ xcb-util-renderutil
 xcb-util-cursor
 enum34
 libnsl
+r-tweenr
+r-rmixmod
 root
 boost-cpp
 teensy_loader_cli
@@ -260,15 +262,7 @@ r-sgeostat
 r-maldiquant
 r-drc
 r-gwasexacthw
-r-ggforce
-r-timsac
-r-fbasics
-r-dqrng
-r-ps
-r-tm
-r-coin
-r-compquadform
-r-pander
+r-ggfoce
 r-restfulr
 r-irlba
 r-rann

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -35,8 +35,6 @@ xcb-util-renderutil
 xcb-util-cursor
 enum34
 libnsl
-r-tweenr
-r-rmixmod
 root
 boost-cpp
 teensy_loader_cli
@@ -241,6 +239,8 @@ r-robustbase
 r-fracdiff
 r-rodbc
 r-rjson
+r-tweenr
+r-rmixmod
 r-sp
 r-pdist
 r-robust
@@ -262,7 +262,15 @@ r-sgeostat
 r-maldiquant
 r-drc
 r-gwasexacthw
-r-ggfoce
+r-ggforce
+r-timsac
+r-fbasics
+r-dqrng
+r-ps
+r-tm
+r-coin
+r-compquadform
+r-pander
 r-restfulr
 r-irlba
 r-rann


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconfuctor-coseq` on Linux aarch64 but currently they fail with the following error:
```
r-ggforce
              [-nothing provides requested r-tweenr >=0.1.5](https://app.travis-ci.com/github/conda-forge/r-ggforce-feedstock/jobs/608328286)

bioconfuctor-coseq
              -nothing provides requested r-rmixmod

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 