### PR TITLE
Add migrator for pugixml 1.13

### DIFF
--- a/recipe/migrations/pugixml113.yaml
+++ b/recipe/migrations/pugixml113.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1692696547
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+pugixml:
+  - '1.13'


### PR DESCRIPTION
Since https://github.com/conda-forge/opencv-feedstock/pull/371, opencv started to depend (transitively) on pugixml, and I started noticing in CI old packages installed due to pugixml conflicts (see https://github.com/robotology/gazebo-yarp-plugins/issues/660). So I noticed that we did not have any pin for pugixml, even if it is a package that contains a shared library with a run_exports (see https://github.com/conda-forge/pugixml-feedstock/blob/7b745ed9c3af0ac3d9a5064d444a59bb88652783/recipe/meta.yaml#L16) and it is a dependency of several packages across conda-forge (https://github.com/search?q=org%3Aconda-forge+pugixml+language%3Ayaml&type=code).

As for example in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3931, first I add a migrator for pugixml 1.13 to ensure that all feedstock use the latest pugixml, and then I intend to add a pin for pugixml once the migrator is done.

fyi @conda-forge/pugixml @conda-forge/opencv 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
