### PR TITLE
Add CUDA 11.8 migrator

### DIFF
--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -89,7 +89,7 @@ fortran_compiler_version:      # [linux and os.environ.get("CF_CUDA_ENABLED", "F
 cdt_name:                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cos7                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-docker_image:                                      # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+docker_image:                                         # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - quay.io/condaforge/linux-anvil-cuda:11.8          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
   # case: native compilation (build == target)
   - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.8  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -58,7 +58,7 @@ __migrator:
       - quay.io/condaforge/linux-anvil-cuda:11.8          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.8          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
 
-      # non-CUDA arch: cross-compilation (build != target)
+      # Native CentOS 7 image
       - quay.io/condaforge/linux-anvil-cos7-x86_64        # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
     cuda_compiler_version:
       - None

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -1,0 +1,91 @@
+migrator_ts: 1692828152
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  paused: false
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  ordering:
+    cxx_compiler_version:
+      - 9
+      - 8
+      - 7
+    c_compiler_version:
+      - 9
+      - 8
+      - 7
+    fortran_compiler_version:
+      - 9
+      - 8
+      - 7
+    docker_image:
+      - quay.io/condaforge/linux-anvil-comp7              # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-aarch64            # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+      - quay.io/condaforge/linux-anvil-ppc64le            # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+      - quay.io/condaforge/linux-anvil-armv7l             # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
+      - quay.io/condaforge/linux-anvil-cuda:9.2           # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:10.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      # case: native compilation (build == target)
+      - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+      - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2  # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+      # case: cross-compilation (build != target)
+      - quay.io/condaforge/linux-anvil-cuda:11.2          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.2          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.8          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      # case: native compilation (build == target)
+      - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.8  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+      - quay.io/condaforge/linux-anvil-aarch64-cuda:11.8  # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+      # case: cross-compilation (build != target)
+      - quay.io/condaforge/linux-anvil-cuda:11.8          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      - quay.io/condaforge/linux-anvil-cuda:11.8          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+      # case: non-CUDA builds
+      - quay.io/condaforge/linux-anvil-cos7-x86_64        # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    cuda_compiler_version:
+      - None
+      - 10.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.1                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.2                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 11.8                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+      - 12.0                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  commit_message: |
+    Rebuild for CUDA 11.8 w/arch support
+
+cuda_compiler:                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version:         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.8                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+c_compiler_version:            # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cxx_compiler_version:          # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+fortran_compiler_version:      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cdt_name:                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cos7                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+docker_image:                                      # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - quay.io/condaforge/linux-anvil-cuda:11.8          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  # case: native compilation (build == target)
+  - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.8  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+  - quay.io/condaforge/linux-anvil-aarch64-cuda:11.8  # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+  # case: cross-compilation (build != target)
+  - quay.io/condaforge/linux-anvil-cuda:11.8          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-cuda:11.8          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -63,11 +63,11 @@ __migrator:
   commit_message: |
     Rebuild for CUDA 11.8 w/arch support
 
-cuda_compiler:                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - nvcc                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler:                 # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-cuda_compiler_version:         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.8                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler_version:         # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.8                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_compiler_version:            # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -26,31 +26,39 @@ __migrator:
       - 8
       - 7
     docker_image:
+      # Native builds
       - quay.io/condaforge/linux-anvil-comp7              # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-aarch64            # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
       - quay.io/condaforge/linux-anvil-ppc64le            # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
       - quay.io/condaforge/linux-anvil-armv7l             # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
+
+      # Legacy CUDAs
       - quay.io/condaforge/linux-anvil-cuda:9.2           # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:10.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:10.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:10.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.0          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.1          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+
+      # CUDA 11.2
       - quay.io/condaforge/linux-anvil-cuda:11.2          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-      # case: native compilation (build == target)
+      # CUDA 11.2 arch: native compilation (build == target)
       - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
       - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2  # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
-      # case: cross-compilation (build != target)
+      # CUDA 11.2 arch: cross-compilation (build != target)
       - quay.io/condaforge/linux-anvil-cuda:11.2          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.2          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+
+      # CUDA 11.8
       - quay.io/condaforge/linux-anvil-cuda:11.8          # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-      # case: native compilation (build == target)
+      # CUDA 11.8 arch: native compilation (build == target)
       - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.8  # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
       - quay.io/condaforge/linux-anvil-aarch64-cuda:11.8  # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
-      # case: cross-compilation (build != target)
+      # CUDA 11.8 arch: cross-compilation (build != target)
       - quay.io/condaforge/linux-anvil-cuda:11.8          # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
       - quay.io/condaforge/linux-anvil-cuda:11.8          # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-      # case: non-CUDA builds
+
+      # non-CUDA arch: cross-compilation (build != target)
       - quay.io/condaforge/linux-anvil-cos7-x86_64        # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
     cuda_compiler_version:
       - None


### PR DESCRIPTION
Adds a migrator to include CUDA 11.8 as discussed in issue ( https://github.com/conda-forge/conda-forge.github.io/issues/1981 ).

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-forge.github.io/issues/1981

Closes https://github.com/conda-forge/ucx-split-feedstock/pull/133
Closes https://github.com/conda-forge/nccl-feedstock/pull/96
Closes https://github.com/conda-forge/pycolmap-feedstock/pull/7

<!--
Please add any other relevant info below:
-->
