### PR TITLE
Add r-qs,r-softimpute, r-tmvtnorm to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -628,6 +628,7 @@ r-proxy
 r-ps
 r-pscl
 r-qlcmatrix
+r-qs
 r-qtl
 r-quadprog
 r-quantreg
@@ -678,6 +679,7 @@ r-slam
 r-slider
 r-sm
 r-sodium
+r-softimpute
 r-som
 r-sp
 r-spam
@@ -695,6 +697,7 @@ r-tiff
 r-timsac
 r-tkrplot
 r-tm
+r-tmvtnorm
 r-tokenizers
 r-tseries
 r-tweedie


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-ctrap, bioconfuctor-zinbwave,bioconfuctor-dep` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-ctrap
              -nothing provides requested r-qs

bioconfuctor-zinbwave
              -nothing provides requested r-softimpute

bioconfuctor-dep
              -nothing provides requested r-imputelcmd->r-tmvtnorm

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 