### PR TITLE
Add r-extrafont,r-hh to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -538,6 +538,7 @@ r-dplr
 r-dqrng
 r-drc
 r-essentials
+r-extrafont
 r-factominer
 r-fastcluster
 r-fastica
@@ -567,6 +568,7 @@ r-grf
 r-gtools
 r-gwasexacthw
 r-haven
+r-hh
 r-hmisc
 r-idpmisc
 r-igraph


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-amplican, bioconfuctor-gispa` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-amplican
              -nothing provides requested r-extrafont

bioconfuctor-gispa
              -nothing provides requested r-hh

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 