### PR TITLE
Add r-riags, r-kknn, r-rsnns,…to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -509,6 +509,7 @@ r-arules
 r-ashr
 r-backbone
 r-base
+r-batchtools
 r-bbmisc
 r-bbmle
 r-bench
@@ -517,6 +518,7 @@ r-bigrquery
 r-bindrcpp
 r-bitops
 r-blockmodeling
+r-cairo
 r-car
 r-catboost
 r-catools
@@ -524,6 +526,7 @@ r-ccapp
 r-changepoint
 r-checkmate
 r-chemometrics
+r-ckmeans.1d.dp
 r-clue
 r-coin
 r-commonmark
@@ -535,6 +538,7 @@ r-dbscan
 r-ddalpha
 r-ddrtree
 r-delaporte
+r-depmixs4
 r-dicedesign
 r-dimred
 r-dixontest
@@ -551,8 +555,11 @@ r-fbasics
 r-fdrtool
 r-feature
 r-fftwtools
+r-fields
 r-filelock
+r-fitdistrplus
 r-flexclust
+r-flock
 r-forecast
 r-fpc
 r-fracdiff
@@ -584,6 +591,7 @@ r-jsonify
 r-jsonvalidate
 r-kableextra
 r-kernlab
+r-kknn
 r-kohonen
 r-lazyeval
 r-lhs
@@ -627,13 +635,17 @@ r-odbc
 r-officer
 r-openxlsx
 r-plsgenomics
+r-plsvarsel
+r-pamr
 r-pander
+r-parmigene
 r-pbivnorm
 r-pbmcapply
 r-pdist
 r-phylobase
 r-pillar
 r-poissonbinomial
+r-praznik
 r-princurve
 r-profvis
 r-proxy
@@ -665,6 +677,7 @@ r-restfulr
 r-reticulate
 r-rfast
 r-rgl
+r-riags
 r-rjava
 r-rjson
 r-rjsonio
@@ -677,8 +690,10 @@ r-robust
 r-robustbase
 r-rocr
 r-rodbc
+r-rootslove
 r-roxygen2
 r-rrcov
+r-rsnns
 r-rsqlite
 r-rsvg
 r-rtsne
@@ -702,6 +717,7 @@ r-splines2
 r-sqldf
 r-statnet.common
 r-survival
+r-survminer
 r-svd
 r-tfmpvalue
 r-this.path
@@ -713,7 +729,9 @@ r-tkrplot
 r-tm
 r-tmvtnorm
 r-tokenizers
+r-truncdist
 r-tseries
+r-tsp
 r-tweedie
 r-tweenr
 r-tzdb


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-cnvrd2, bioconductor-damirseq, bioconfuctor-inspect, bioconfuctor-knowseq, bioconfuctor-cocoa, bioconfuctor-contibait, bioconfuctor-demixt, bioconfuctor-htseqgenie, bioconfuctor-icnv, bioconfuctor-inpas, bioconfuctor-gdcrnatools, bioconfuctor-genomicozone, bioconfuctor-moonlightr` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-cnvrd2
              -nothing provides requested r-riags

bioconductor-damirseq
              -nothing provides requested r-kknn
              -nothing provides requested r-rsnns
              -nothing provides requested r-plsvarsel

bioconfuctor-inspect
              -nothing provides requested r-rootslove

bioconfuctor-knowseq
              -nothing provides requested r-praznik

bioconfuctor-cocoa
              -nothing provides requested r-fitdistrplus

bioconfuctor-contibait
              -nothing provides requested r-tsp

bioconfuctor-demixt
              -nothing provides requested r-truncdist

bioconfuctor-htseqgenie
              -nothing provides requested r-cairo

bioconfuctor-icnv
              -nothing provides requested r-fields

bioconfuctor-inpas
              -nothing provides requested r-batchtools
              -nothing provides requested r-depmixs4
              -nothing provides requested r-flock

bioconfuctor-gdcrnatools
              -nothing provides requested r-survminer

bioconfuctor-genomicozone
              -nothing provides requested r-ckmeans.1d.dp

bioconfuctor-moonlightr
              -nothing provides requested r-parmigene

bioconductor-mlseq
              -nothing provides requested r-pamr

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 