### PR TITLE
Add r-clusterr, r-ecp, r-spp, r-nbpseq, …to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -528,6 +528,7 @@ r-checkmate
 r-chemometrics
 r-ckmeans.1d.dp
 r-clue
+r-clusterr
 r-coin
 r-commonmark
 r-compositions
@@ -545,6 +546,7 @@ r-dixontest
 r-dplr
 r-dqrng
 r-drc
+r-ecp
 r-essentials
 r-extrafont
 r-factominer
@@ -581,6 +583,7 @@ r-gtools
 r-gwasexacthw
 r-haven
 r-hh
+r-hiddenmarkov
 r-hmisc
 r-idpmisc
 r-igraph
@@ -624,6 +627,7 @@ r-mnormt
 r-multicool
 r-mvoutlier
 r-mvtnorm
+r-nbpseq
 r-ncdf4
 r-network
 r-nleqslv
@@ -634,6 +638,8 @@ r-norm
 r-odbc
 r-officer
 r-openxlsx
+r-paralleldist
+r-phyclust
 r-plsgenomics
 r-plsvarsel
 r-pamr
@@ -678,6 +684,7 @@ r-reticulate
 r-rfast
 r-rgl
 r-riags
+r-rjags
 r-rjava
 r-rjson
 r-rjsonio
@@ -700,6 +707,7 @@ r-rtsne
 r-s2
 r-scales
 r-seqinr
+r-seurat
 r-sfheaders
 r-sgeostat
 r-shinywidgets
@@ -715,6 +723,7 @@ r-sparsem
 r-spdep
 r-splines2
 r-sqldf
+r-spp
 r-statnet.common
 r-survival
 r-survminer

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -641,9 +641,9 @@ r-norm
 r-odbc
 r-officer
 r-openxlsx
-r-paralleldist
 r-pamr
 r-pander
+r-paralleldist
 r-parmigene
 r-pbivnorm
 r-pbmcapply
@@ -725,8 +725,8 @@ r-spam
 r-sparsem
 r-spdep
 r-splines2
-r-sqldf
 r-spp
+r-sqldf
 r-statnet.common
 r-survival
 r-survminer


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconductor-mlseq, bioconductor-aneufinder, bioconfuctor-chic, bioconfuctor-desubs, bioconfuctor-infercnv` on Linux aarch64 but currently they fail with the following error:
```
bioconductor-mlseq
              -nothing provides requested r-clusterr

bioconductor-aneufinder
              -nothing provides requested r-ecp

bioconfuctor-chic
              -nothing provides requested r-spp

bioconfuctor-desubs
              -nothing provides requested r-nbpseq

bioconfuctor-infercnv
              -nothing provides requested r-paralleldist
              -nothing provides requested r-hiddenmarkov
              -nothing provides requested r-phyclust
              -nothing provides requested r-seurat
              -nothing provides requested r-rjags


```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 