### PR TITLE
Add migration for libavif 1.0.1

### DIFF
--- a/recipe/migrations/libavif101.yaml
+++ b/recipe/migrations/libavif101.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1694052176
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libavif:
+  - '1.0.1'


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4884
@carterbox is this the right migration to make for this given the new structure?
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
