### PR TITLE
Add jags, update r-rootsolve in arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -227,6 +227,7 @@ ipykernel
 ipython
 islpy
 jaeger
+jags
 jaxlib
 jaydebeapi
 jbig
@@ -697,7 +698,7 @@ r-robust
 r-robustbase
 r-rocr
 r-rodbc
-r-rootslove
+r-rootsolve
 r-roxygen2
 r-rrcov
 r-rsnns


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconfuctor-inspect, bioconfuctor-infercnv` on Linux aarch64 but currently they fail with the following error:
```
bioconfuctor-inspect
              -nothing provides requested r-rootsolve rather than r-rootslove

bioconfuctor-infercnv
              -nothing provides requested jags

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 