### PR TITLE
Add r-remacor, r-rcppml to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -670,6 +670,7 @@ r-rconv
 r-rcppcnpy
 r-rcppeigen
 r-rcpphnsw
+r-rcppml
 r-rcppnumerical
 r-rcpproll
 r-rcppspdlog
@@ -677,6 +678,7 @@ r-rcurl
 r-rdpack
 r-readr
 r-recommended
+r-remacor
 r-reprex
 r-reshape
 r-reshape2


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `bioconfuctor-muscat` on Linux aarch64 but currently they fail with the following error:
```
bioconfuctor-muscat
              -nothing provides r-remacor needed by bioconductor-variancepartition
              -nothing provides r-rcppml needed by bioconductor-scater

```
l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 