### PR TITLE
Add a pin for pulse-audio-client

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -654,6 +654,10 @@ proj:
   - 9.2.0
 pulseaudio:
   - '16.1'
+pulseaudio_client:
+  - '16.1'
+pulseaudio_daemon:
+  - '16.1'
 pybind11_abi:
   - 4
 python:


### PR DESCRIPTION
In https://github.com/conda-forge/pulseaudio-feedstock/pull/32 and https://github.com/conda-forge/pulseaudio-feedstock/pull/33 the package was split giving finer grained dependencies
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
