### PR TITLE
Add osdf-client to arch rebuilds

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -391,6 +391,7 @@ orange3
 oras
 orc
 orocos-kdl
+osdf-client
 oso
 ovito
 pagmo

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -701,6 +701,7 @@ orc
 orderedset
 orocos-kdl
 ortools-python
+osdf-client
 osmium-tool
 oso
 ovito


### PR DESCRIPTION
This PR adds `osdf-client` to the Linux arch and macOS arm64 rebuilds.

I can't remember whether those files list _feedstocks_ or _packages_, I have included the name of the feedstock. Is that's wrong, please let me know. Ta.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
