### PR TITLE
provide linter hints where they don't require new smithy releases to update

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -1,0 +1,21 @@
+[hints]
+# mapping from output-name-to-warn-on to hint-to-display
+matplotlib = """\
+    Recipes should usually depend on `matplotlib-base` as opposed to \
+    `matplotlib` so that runtime environments do not require large \
+    packages like `qt`."""
+jpeg = """\
+    Recipes should usually depend on `libjpeg-turbo` as opposed to \
+    `jpeg` for improved performance. For more information please see \
+    https://github.com/conda-forge/conda-forge.github.io/issues/673."""
+pytorch-cpu = """\
+    Please depend on `pytorch` directly, in order to avoid forcing \
+    CUDA users to downgrade to the CPU version for no reason."""
+pytorch-gpu = """\
+    Please depend on `pytorch` directly. If your package definitely \
+    requires the CUDA version, please depend on `pytorch =*=cuda*`."""
+
+# packages that have been renamed
+abseil-cpp = "The `abseil-cpp` output has been superseded by `libabseil`"
+grpc-cpp = "The `grpc-cpp` output has been superseded by `libgrpc`"
+build = "The pypa `build` package has been renamed to `python-build`"


### PR DESCRIPTION
After discussion in https://github.com/conda-forge/conda-smithy/issues/1740, add the linter hints to the pinning repo. In an upcoming smithy update, we would then download the raw github sources of this file and parse the `specific_hints` dictionary out of it.

I chose toml as a file format because it's _much_ more sane than YAML (IMO) for being able to do line breaks, while keeping single-line strings in the resulting strings (see [spec](https://toml.io/en/v1.0.0#string); to clarify: all the strings produced by this PR are single-line and single-spaced, with no extra whitespace before/after).

Ultimately, the format and the file name and the path is secondary though - if someone has better suggestions, please speak up!

Starts with initial set of hints from https://github.com/conda-forge/conda-smithy/pull/1734 == current state of smithy

Closes https://github.com/conda-forge/conda-smithy/issues/1740

