### PR TITLE
add msgpack_{c,cxx} to pinning (after closed migration)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -566,6 +566,10 @@ mpich:
   - 4
 mpfr:
   - 4
+msgpack_c:
+  - 6
+msgpack_cxx:
+  - 6
 mumps_mpi:
   - 5.2.1
 mumps_seq:


### PR DESCRIPTION
This was missed in #4854, not sure why the bot messed that up CC @beckermr 