### PR TITLE
finish combined abseil/grpc/protobuf migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -420,7 +420,7 @@ kealib:
 krb5:
   - '1.20'
 libabseil:
-  - '20230125'
+  - '20230802'
 libabseil_static:
   - '20220623.0'
 libaec:
@@ -468,7 +468,7 @@ libgit2:
 libgoogle_cloud:
   - '2.12'
 libgrpc:
-  - '1.56'
+  - '1.57'
 libhugetlbfs:
   - 2
 libhwy:
@@ -498,7 +498,7 @@ libpcap:
 libpng:
   - 1.6
 libprotobuf:
-  - 4.23.3
+  - 4.23.4
 libpq:
   - 15
 libraw:

--- a/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
+++ b/recipe/migrations/libabseil20230802_libgrpc157_libprotobuf4234.yaml
@@ -2,12 +2,9 @@ __migrator:
   build_number: 1
   kind: version
   migration_number: 1
-libabseil:
-- 20230802
-libgrpc:
-- "1.57"
-libprotobuf:
-- 4.23.4
+# need to keep this in the migrator until we're ready
+# to bump the deployment target conda-forge-wide, see
+# https://github.com/conda-forge/conda-forge.github.io/issues/1844#issuecomment-1734933359
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
 - "10.13"                  # [osx and x86_64]
 migrator_ts: 1692632590.658328


### PR DESCRIPTION
Needed to start new migration that'll probably be necessary for tensorflow, see https://github.com/conda-forge/libprotobuf-feedstock/pull/185 / https://github.com/conda-forge/tensorflow-feedstock/pull/329

~Biggest issue with this is actually if we're ready to bump the `MACOSX_DEPLOYMENT_TARGET` globally (it was suggested to include this in the migrator in the context of https://github.com/conda-forge/conda-forge.github.io/issues/1844 resp. https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4814)~

TODO:
* [ ] https://github.com/conda-forge/obake-feedstock/pull/41 (needs new version)
* [ ] https://github.com/conda-forge/or-tools-feedstock/pull/48 (needs new version)
* [ ] https://github.com/conda-forge/protozfits-feedstock/pull/24
* [ ] https://github.com/conda-forge/pyaudi-feedstock (waiting for obake)
* [ ] https://github.com/conda-forge/tensorflow-feedstock (attempted [here](https://github.com/conda-forge/tensorflow-feedstock/pull/329), might skip to 4.24 directly)
* [x] https://github.com/conda-forge/singlejar-feedstock/pull/29 (done despite the migrator showing bot error)

Obsolete (missed the last few migrations already)
* https://github.com/conda-forge/bear-feedstock/pull/39
* https://github.com/conda-forge/mongodb-feedstock/pull/76
* https://github.com/conda-forge/go-cockroach-feedstock
* https://github.com/conda-forge/mysql-connector-python-feedstock
* https://github.com/conda-forge/tomviz-feedstock

Xref #4075