### PR TITLE
Add dipy to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -131,6 +131,7 @@ deno-dom
 dgl
 diffutils
 digital_rf
+dipy
 dirac-grid
 distributed
 dm-tree


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

From a look at its dependencies:
https://github.com/conda-forge/dipy-feedstock/blob/790d2cb6b2b1cc8547aa707253d1125d921ba6fe/recipe/meta.yaml#L32-L46

Only `nibabel` is missing `aarch64/ppc64le`, and its dependencies are available:

https://github.com/conda-forge/nibabel-feedstock/blob/bfb0fd76554ae640730aaeff74ae86f9c342a3d4/recipe/meta.yaml#L40-L50



<!--
Please add any other relevant info below:
-->
