### PR TITLE
add special boost migrator

### DIFF
--- a/recipe/migrations/boost_cpp_to_libboost.yaml
+++ b/recipe/migrations/boost_cpp_to_libboost.yaml
@@ -13,3 +13,8 @@ libboost_devel:
 # that will replace boost-cpp with libboost-devel
 boost_cpp:
   - 1.82
+# same for boost -> libboost-python-devel
+libboost_python_devel:
+  - 1.82
+boost:
+  - 1.82

--- a/recipe/migrations/boost_cpp_to_libboost.yaml
+++ b/recipe/migrations/boost_cpp_to_libboost.yaml
@@ -1,0 +1,15 @@
+migrator_ts: 1695775149
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: "Rebuild for libboost 1.82"
+  # limit the number of prs to do the initial test
+  pr_limit: 1
+libboost_devel:
+  - 1.82
+# This migration is matched with a piggy-back migrator
+# (see https://github.com/regro/cf-scripts/pull/1668)
+# that will replace boost-cpp with libboost-devel
+boost_cpp:
+  - 1.82


### PR DESCRIPTION
This is following https://github.com/conda-forge/boost-feedstock/pull/164, adding a special migrator for https://github.com/regro/cf-scripts/pull/1668 to piggy-back onto.

I've tried to follow the example of libjpeg-turbo (#4091 & https://github.com/regro/cf-scripts/pull/1602) closely.

Question of timing is still open (especially now that the 3.12 migration has started), but I wanted to open the PR at least.