### PR TITLE
Add linter rule about use of obsolete `arrow-cpp`

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -16,6 +16,6 @@ pytorch-gpu = """\
     requires the CUDA version, please depend on `pytorch =*=cuda*`."""
 
 # packages that have been renamed
-abseil-cpp = "The `abseil-cpp` output has been superseded by `libabseil`"
-grpc-cpp = "The `grpc-cpp` output has been superseded by `libgrpc`"
-build = "The pypa `build` package has been renamed to `python-build`"
+abseil-cpp = "The `abseil-cpp` output has been superseded by `libabseil`."
+grpc-cpp = "The `grpc-cpp` output has been superseded by `libgrpc`."
+build = "The pypa `build` package has been renamed to `python-build`."

--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -17,5 +17,6 @@ pytorch-gpu = """\
 
 # packages that have been renamed
 abseil-cpp = "The `abseil-cpp` output has been superseded by `libabseil`."
+arrow-cpp = "The `arrow-cpp` output has been superseded by `libarrow`."
 grpc-cpp = "The `grpc-cpp` output has been superseded by `libgrpc`."
 build = "The pypa `build` package has been renamed to `python-build`."


### PR DESCRIPTION
Libarrow got introduced with v10, and since we support 4 versions at a time, this meant waiting at least until v13, before all our supported versions have a `libarrow` output, and we can remove the `arrow-cpp` compatibility wrapper.

For v13, we decided not to remove the wrappers yet, but are planning to do so for v14. Now that we have nice(r) infrastructure for adding hints to the linter, use it to start warning about remaining use of `arrow-cpp`.

CC @conda-forge/arrow-cpp