### PR TITLE
add max_solver_attempts to boost migration

### DIFF
--- a/recipe/migrations/boost_cpp_to_libboost.yaml
+++ b/recipe/migrations/boost_cpp_to_libboost.yaml
@@ -6,6 +6,7 @@ __migrator:
   commit_message: "Rebuild for libboost 1.82"
   # limit the number of prs for ramp-up
   pr_limit: 10
+  max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 3 times
 libboost_devel:
   - 1.82
 # This migration is matched with a piggy-back migrator


### PR DESCRIPTION
I don't know what the default behaviour is, but there was an outage (causing package uploads to fail) early in the migration, and the bot hasn't retried any of those despite the packages being there now.