### PR TITLE
increase bot share of boost migration

### DIFF
--- a/recipe/migrations/boost_cpp_to_libboost.yaml
+++ b/recipe/migrations/boost_cpp_to_libboost.yaml
@@ -5,7 +5,7 @@ __migrator:
   bump_number: 1
   commit_message: "Rebuild for libboost 1.82"
   # limit the number of prs for ramp-up
-  pr_limit: 10
+  pr_limit: 20
   max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 3 times
 libboost_devel:
   - 1.82


### PR DESCRIPTION
We're down to packages with 0 or 1 children, aside from the bot retrying previously failed (or already manually done) deps. So give it a bit more to chew on.