### PR TITLE
switch python 3.12 migration to use main channel

### DIFF
--- a/recipe/migrations/python312.yaml
+++ b/recipe/migrations/python312.yaml
@@ -28,13 +28,9 @@ __migrator:
       - cross-python
       - python_abi
     exclude_pinned_pkgs: false
-    additional_zip_keys:
-      - channel_sources
 
 python:
   - 3.12.* *_cpython
-channel_sources:
-  - conda-forge/label/python_rc,conda-forge
 # additional entries to add for zip_keys
 numpy:
   - 1.26


### PR DESCRIPTION
https://github.com/conda-forge/python-feedstock/pull/651 was merged, so we don't need the rc-channel in the migrator anymore.