### PR TITLE
Bump Python 3.12 solver attempts

### DIFF
--- a/recipe/migrations/python312.yaml
+++ b/recipe/migrations/python312.yaml
@@ -19,7 +19,7 @@ __migrator:
     paused: false
     longterm: True
     pr_limit: 30
-    max_solver_attempts: 5  # this will make the bot retry "not solvable" stuff 5 times
+    max_solver_attempts: 6  # this will make the bot retry "not solvable" stuff 6 times
     exclude:
       # this shouldn't attempt to modify the python feedstocks
       - python


### PR DESCRIPTION
This should unblock `scipy` and will update the solver errors with the new extended format for all other that currently error out.