### PR TITLE
Add ucx 1.15.0 migrator

### DIFF
--- a/recipe/migrations/ucx1150.yaml
+++ b/recipe/migrations/ucx1150.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+ucx:
+- '1.15.0'
+migrator_ts: 1696558865


### PR DESCRIPTION
Not sure why the bot isn't creating PRs for ucx automatically. Same happened for previous versions in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4256