### PR TITLE
add migration for re2

### DIFF
--- a/recipe/migrations/re220230602.yaml
+++ b/recipe/migrations/re220230602.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  commit_message: "Rebuild for re2 2023.06.02"
+migrator_ts: 1697153785.6780672
+re2:
+- 2023.06.02


### PR DESCRIPTION
It's taken a while to get https://github.com/conda-forge/re2-feedstock/pull/68 merged, but it seems the bot didn't pick up the new builds, so do it manually.

Note that the mechanics are [changing](https://github.com/conda-forge/re2-feedstock/issues/67) (improving) slightly for re2 going forward: we need to keep using `re2` in the pinning, but as long as the SOVERSION or re2 is not bumped, we can forgo the migration and just directly bump to the new version in the global pinning. I intend to try test this with https://github.com/conda-forge/re2-feedstock/pull/71 once this migration has run its course.

CC @conda-forge/re2