### PR TITLE
Add migrator for bullet-cpp 3.25

### DIFF
--- a/recipe/migrations/bullet_cpp325.patch
+++ b/recipe/migrations/bullet_cpp325.patch
@@ -1,0 +1,8 @@
+migrator_ts: 1697202337
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+bullet_cpp:
+  - '3.25'


### PR DESCRIPTION
We do not have any pin for bullet-cpp, even if it is a package that contains a shared library with a run_exports (see https://github.com/conda-forge/bullet-feedstock/blob/07cd09cf37756bcaef13683441aea8a269cd56be/recipe/meta.yaml#L30) and it is a dependency of several packages across conda-forge (https://github.com/search?q=org%3Aconda-forge+bullet-cpp+language%3AYAML&type=code).

As done for example in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3931, first I add a migrator for bullet-cpp 3.25 to ensure that all feedstocks use the latest bullet-cpp, and then I intend to add a pin for bullet-cpp once the migrator is done.

Eventually this will fix https://github.com/conda-forge/gz-sim-feedstock/issues/33 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
