### PR TITLE
Add bullet_cpp pin to conda_build_config.yaml

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -270,6 +270,8 @@ boost:
   - 1.78.0
 boost_cpp:
   - 1.78.0
+bullet_cpp:
+  - 3.25
 bzip2:
   - 1
 c_ares:


### PR DESCRIPTION
After https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5025 and https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5049, we are ready to add a pin for `bullet_cpp` .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
