### PR TITLE
Drop openturns pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -621,8 +621,6 @@ openmpi:
   - 4
 openssl:
   - '3'
-openturns:
-  - '1.20'
 orc:
   - 1.9.0
 pango:


### PR DESCRIPTION
I manuaylly update the openturns subpackages at each release anyways and this just creates duplicate automatic PRs.
The other packages (batman & gemseo) that depend on openturns either use manually pinned versions or older versions.

Closes #4599