### PR TITLE
begin migration for zeromq 4.3.5

### DIFF
--- a/recipe/migrations/zeromq435.yaml
+++ b/recipe/migrations/zeromq435.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1698047052
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+zeromq:
+  - '4.3.5'


### PR DESCRIPTION
Only Windows really needs a migrator for patch releases, as 4.3.5 is already accepted by the existing builds on other platforms. But Windows builds have strict pinning due to library naming.