### PR TITLE
Add r-biasedurn, r-ruv on arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -553,6 +553,7 @@ r-batchtools
 r-bbmisc
 r-bbmle
 r-bench
+r-biasedurn
 r-biglm
 r-bigrquery
 r-bindrcpp
@@ -750,6 +751,7 @@ r-rsnns
 r-rsqlite
 r-rsvg
 r-rtsne
+r-ruv
 r-s2
 r-scales
 r-seqinr


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

l need to build  `r-biasedurn, r-ruv` on Linux aarch64 but currently they fail with the following error:

l hope that with the proposed modifications in this PR they will be usable on LInux aarch64 