### PR TITLE
Add lsdeluxe to the list of packages to be supported on osx-arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -564,6 +564,7 @@ loky
 lp_solve
 lru-dict
 lsst-documenteer
+lsdeluxe
 luajit
 luarocks
 lue

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -563,8 +563,8 @@ log4cxx
 loky
 lp_solve
 lru-dict
-lsst-documenteer
 lsdeluxe
+lsst-documenteer
 luajit
 luarocks
 lue


### PR DESCRIPTION
Add lsdeluxe to the list of packages for osx-arm64.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
