### PR TITLE
Add CUDA 12 Windows

### DIFF
--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    2
+    3
   build_number:
     1
   paused: false
@@ -53,7 +53,7 @@ __migrator:
       - 11.2                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
       - 12.0                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   commit_message: |
-    Rebuild for CUDA 12 w/arch support
+    Rebuild for CUDA 12 w/arch + Windows support
     
     The transition to CUDA 12 SDK includes new packages for all CUDA libraries and
     build tools. Notably, the cudatoolkit package no longer exists, and packages
@@ -62,11 +62,11 @@ __migrator:
     [see this issue]( https://github.com/conda-forge/conda-forge.github.io/issues/1963 ).
     Please feel free to raise any issues encountered there. Thank you! :pray:
 
-cuda_compiler:                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cuda-nvcc                  # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler:                 # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cuda-nvcc                  # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-cuda_compiler_version:         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 12.0                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler_version:         # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12.0                       # [(linux or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_compiler_version:            # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
This adds Windows to the CUDA 12 migrator.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
