### PR TITLE
Close pugixml113 migration and pin pugixml to 1.13

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -635,6 +635,8 @@ petsc:
   - '3.19'
 petsc4py:
   - '3.19'
+pugixml:
+  - '1.13'
 slepc:
   - '3.19'
 slepc4py:

--- a/recipe/migrations/pugixml113.yaml
+++ b/recipe/migrations/pugixml113.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1692696547
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-pugixml:
-  - '1.13'


### PR DESCRIPTION
Close the migration opened in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4824 .

The only not migrated feedstocks are:
* gfal2: PR build failure, but the package has several upstream issues and also new releases are not merged, see https://github.com/conda-forge/gfal2-feedstock/pull/41 and https://github.com/conda-forge/gfal2-feedstock/pulls 
* tomviz: Package currently not working for Python >=3.8, see https://github.com/conda-forge/tomviz-feedstock/issues/34  

However, I think we can avoid blocking the migration on this two packages, even as pugixml 1.14 was released (see https://github.com/conda-forge/pugixml-feedstock/pull/26) and personally I am experience some intricated issues related to this (see https://github.com/ami-iit/ironcub_mk1_software/issues/11#issuecomment-1802102145 and https://github.com/conda-forge/openvino-feedstock/issues/52). 

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
