### PR TITLE
Close libmatio1524 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -486,7 +486,7 @@ libkml:
 libiio:
   - 0
 libmatio:
-  - 1.5.23
+  - 1.5.24
 libmicrohttpd:
   - 0.9
 libnetcdf:

--- a/recipe/migrations/libmatio1524.yaml
+++ b/recipe/migrations/libmatio1524.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libmatio:
-- 1.5.24
-migrator_ts: 1698498158.247274


### PR DESCRIPTION
Close libmatio1524, as matio 15.2.5 was just released (https://github.com/tbeu/matio/releases/tag/v1.5.25) as the only missing packages are ones for which also libmatio1523 migration was not completed:
* https://github.com/conda-forge/trilinos-feedstock/pulls
* https://github.com/conda-forge/pytrilinos-feedstock/pulls
* https://github.com/conda-forge/scilab-feedstock/pulls

See also https://github.com/conda-forge/conda-forge.github.io/issues/1724 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
