### PR TITLE
Migrate libopentelemetry

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -504,6 +504,8 @@ libnetcdf:
   - 4.9.2
 libopencv:
   - 4.8.1
+libopentelemetry_cpp:
+  - '1.9'
 libosqp:
   - 0.6.3
 libpcap:

--- a/recipe/migrations/libopentelemetry_cpp112.yaml
+++ b/recipe/migrations/libopentelemetry_cpp112.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libopentelemetry_cpp:
+- 1.12
+migrator_ts: 1701390100.9928305


### PR DESCRIPTION
We already did an initial migration, but #4420 did not add the pin correctly.