### PR TITLE
Add pin for libmatio-cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -498,6 +498,8 @@ libiio:
   - 0
 libmatio:
   - 1.5.24
+libmatio_cpp:
+  - 0.2.3
 libmicrohttpd:
   - 0.9
 libnetcdf:


### PR DESCRIPTION
libmatio-cpp is a shared library with `run_exports` (see https://github.com/conda-forge/libmatio-cpp-feedstock/blob/main/recipe/meta.yaml#L22) on which more than a package depends (see https://github.com/conda-forge/librobometry-feedstock/blob/f8cf6ff1505d1f273125da779ccfb1424ff32de2/recipe/meta.yaml#L33 and https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/blob/986c61d359ef06ac59bc3565e8018eab5420e3b3/recipe/meta.yaml#L54). All dependent packages have been built to 0.2.3, so there is no need to add a 0.2.3 migration, we can directly pin to 0.2.3 .


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
