### PR TITLE
Fix Singular version

### DIFF
--- a/recipe/migrations/singular4328.yaml
+++ b/recipe/migrations/singular4328.yaml
@@ -4,4 +4,4 @@ __migrator:
   migration_number: 1
 migrator_ts: 1701944250.6100492
 singular:
-- 4.3.2.8
+- 4.3.2.p8


### PR DESCRIPTION
somehow the bot got this one wrong and stripped the `p`.

However, as can be seen here:
https://anaconda.org/conda-forge/singular/files, the version should have that `p` in there.

This fixes the migration from #5247.

This had happened before btw, see #1535.
