### PR TITLE
Add global pin for libsoup

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -530,6 +530,9 @@ libsentencepiece:
   - '0.1.99'
 libsndfile:
   - '1.2'
+libsoup:
+  - 2      # [win]
+  - 3      # [not win]
 libspatialindex:
   - 1.9.3
 libssh:


### PR DESCRIPTION
Ultimately, I soon want to start a migration for windows with libsoup 2->3 for windows

cc: @conda-forge/libsoup


xref: https://github.com/conda-forge/libsoup-feedstock/issues/46
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
