### PR TITLE
Fix `mkl_devel` pin to match `mkl` one after closing mkl 2023 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -587,7 +587,7 @@ mimalloc:
 mkl:
   - '2023'
 mkl_devel:
-  - 2022
+  - 2023
 mpg123:
   - '1.32'
 mpich:


### PR DESCRIPTION
As noticed in https://github.com/conda-forge/numexpr-feedstock/pull/58, closing the mkl 2023 migration in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5129 introduced a mismatch between `mkl` and `mkl_devel`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
