### PR TITLE
migrate tensorflow & libtensorflow & libtensorflow_cc

### DIFF
--- a/recipe/migrations/tensorflow215.yaml
+++ b/recipe/migrations/tensorflow215.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+tensorflow:
+- "2.15"
+libtensorflow:
+- "2.15"
+libtensorflow_cc:
+- "2.15"
+migrator_ts: 1703220692.673541


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Manually add migrations since the bot doesn't work. ping @conda-forge/tensorflow

The bot has the following error:
```
2023-12-21T21:16:47.0869617Z 2023-12-21 21:16:47,086 INFO     conda_forge_tick.utils || could not parse run export for pinning: 'libtensorflow 2.15.0'
2023-12-21T21:16:47.0871440Z 2023-12-21 21:16:47,086 INFO     conda_forge_tick.utils || could not parse run export for pinning: 'libtensorflow_cc 2.15.0'
2023-12-21T21:16:47.1455876Z 2023-12-21 21:16:47,145 INFO     conda_forge_tick.utils || could not parse run export for pinning: 'libtensorflow 2.15.0'
2023-12-21T21:16:47.1457979Z 2023-12-21 21:16:47,145 INFO     conda_forge_tick.utils || could not parse run export for pinning: 'libtensorflow_cc 2.15.0'
```

I guess the reason is that there is no feedstock called `libtensorflow` or `libtensorflow_cc`, but the bot only finds the package in this way. I notice `libsentencepiece` has the same issue.