### PR TITLE
Add sunode to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1279,6 +1279,7 @@ stumpy
 subversion
 suds-jurko
 suitesparse
+sunode
 sunpy
 supervisor
 swig


### PR DESCRIPTION
Following instructions on
https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/ I am adding the packages `sunode` to the list of packages supporting osx-arm64 architecture, after having checked that it does compile nicely on that platform.

Fixes https://github.com/pymc-devs/sunode/issues/46

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

As per my previous similar PR https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4191 , the rest of the checklist doesn't apply.