### PR TITLE
tighten pin in fmt migration

### DIFF
--- a/recipe/migrations/fmt10.yaml
+++ b/recipe/migrations/fmt10.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind: version
   migration_number: 1
 fmt:
-- '10'
+- '10.1'
 spdlog:
 - '1.12'
 migrator_ts: 1683802784.4940007


### PR DESCRIPTION
Fmt 10.2 turned out not to be ABI compatible, see https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/628 and linked issues.