### PR TITLE
Add basemap to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -28,6 +28,7 @@ awscli2
 awscrt
 backports.zoneinfo
 backward-cpp
+basemap
 bat
 bayeswave
 bazel


### PR DESCRIPTION
Checklist:
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

Requested to get linux/aarch64 migration for `basemap-feedstock`, since `@conda-forge-admin, please add linux-aarch64` does not seem to have effect (see https://github.com/conda-forge/basemap-feedstock/issues/124).