### PR TITLE
[RFC] Match conda-smithy's `--exclusive-file` structure

### DIFF
--- a/recipe/share/conda-forge/migrations
+++ b/recipe/share/conda-forge/migrations
@@ -1,0 +1,1 @@
+../../migrations


### PR DESCRIPTION
When using conda-smithy's `--exclusive-file` flag, conda-smithy expects that the exclusive file will live in a specific location relative to the `conda_build_config.yaml` file used as the exclusive file. In particular it expects to find the migrations in `./share/conda-forge/migrations` where `.` contains `conda_build_config.yaml`.

However this makes it tricky to test new migration changes in `conda-forge-pinning` on feedstocks via `--exclusive-file`. As a remedy create the same directory structure in `conda-forge-pinning` and use a symlink to map the `migrations` folder to the location `conda-smithy` expects. This way when using `--exclusive-file` with `conda-forge-pinning` any local migration changes are picked up and applied as well.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
