### PR TITLE
osx-arm64 migrate `r-dicedesign`, `r-lhs`

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1032,6 +1032,7 @@ r-cubature
 r-desctools
 r-desolve
 r-devtools
+r-dicedesign
 r-diptest
 r-distributionutils
 r-duckdb
@@ -1068,6 +1069,7 @@ r-languageserver
 r-latticeextra
 r-leaps
 r-lfe
+r-lhs
 r-liblinear
 r-lightgbm
 r-lme4


### PR DESCRIPTION
A couple more migrations needed for `r-tidymodels`.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
