### PR TITLE
Stop libxml2 2.12 migration as it's unnecessary

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -579,7 +579,7 @@ libwebp:
 libwebp_base:
   - 1
 libxml2:
-  - '2.11'
+  - 2
 libxsmm:
   - 1
 libuuid:

--- a/recipe/migrations/libxml2212.yaml
+++ b/recipe/migrations/libxml2212.yaml
@@ -3,5 +3,5 @@ __migrator:
   kind: version
   migration_number: 1
 libxml2:
-- '2.12'
+- 2
 migrator_ts: 1700445986.2150207


### PR DESCRIPTION
See https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/634