### PR TITLE
Add lsst-sphgeom to osx_arm migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -582,6 +582,7 @@ lp_solve
 lru-dict
 lsdeluxe
 lsst-documenteer
+lsst-sphgeom
 luajit
 luarocks
 lue


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

Adds `osx-arm` support for the lsst-sphgeom package as per given [instructions](https://conda-forge.org/blog/2020/10/29/macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock).