### PR TITLE
osx-arm64 migrate `r-quickjsr`

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1103,6 +1103,7 @@ r-png
 r-qgam
 r-quadprog
 r-quantreg
+r-quickjsr
 r-ragg
 r-raster
 r-rbibutils


### PR DESCRIPTION
The `r-quickjsr` package is a new dependency of `r-stan` (see https://github.com/conda-forge/r-rstan-feedstock/pull/33).

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
