### PR TITLE
halt metis 5.1.1 migration

### DIFF
--- a/recipe/migrations/metis511.yaml
+++ b/recipe/migrations/metis511.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-metis:
-- 5.1.1
-migrator_ts: 1693327026.336058


### PR DESCRIPTION
metis 5.1.1 has been causing trouble, and folks [are suggesting](https://github.com/conda-forge/mumps-feedstock/issues/106#issuecomment-1898508040) holding off on migrating from 5.1.0 until [5.2.1 is ready](https://github.com/conda-forge/metis-feedstock/pull/41)

Packages that have been migrated, which may need a fresh build for 5.1.0 (if there have been other updates):

[suitesparse](https://github.com/conda-forge/suitesparse-feedstock) (6)
Immediate Children: colmap, gtsam, match-series, petsc, proteus, pycolmap
[mumps](https://github.com/conda-forge/mumps-feedstock) (3)
Immediate Children: ipopt, petsc, proteus
[superlu_dist](https://github.com/conda-forge/superlu_dist-feedstock) (2)
Immediate Children: petsc, proteus
[colmap](https://github.com/conda-forge/colmap-feedstock) (1)
Immediate Children: pycolmap
[petsc](https://github.com/conda-forge/petsc-feedstock) (1)
Immediate Children: proteus
[spral](https://github.com/conda-forge/spral-feedstock) (1)
Immediate Children: ipopt
[pycolmap](https://github.com/conda-forge/pycolmap-feedstock) (0)
[kahip](https://github.com/conda-forge/kahip-feedstock) (0)
[pymetis](https://github.com/conda-forge/pymetis-feedstock) (0)
[dgl](https://github.com/conda-forge/dgl-feedstock) (0)

cc @traversaro @akhmerov