### PR TITLE
Pin metis 5.1.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -595,7 +595,7 @@ lz4_c:
 lzo:
   - 2
 metis:
-  - 5.1
+  - 5.1.0
 mimalloc:
   - 2.1.2
 mkl:


### PR DESCRIPTION
rather than just 5.1, since 5.1.1 has compatibility issues

should have been part of #5396 