### PR TITLE
Add OpenSlide to pinnings and start OpenSlide 4 migrator

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -660,6 +660,8 @@ openjpeg:
   - '2'
 openmpi:
   - 4
+openslide:
+  - 3
 openssl:
   - '3'
 orc:

--- a/recipe/migrations/openslide4.yaml
+++ b/recipe/migrations/openslide4.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for openslide 4
+  kind: version
+  migration_number: 1
+openslide:
+- 4
+migrator_ts: 1706069399


### PR DESCRIPTION
As OpenSlide has a `run_exports` set starting with 3.4.1 ( https://github.com/conda-forge/openslide-feedstock/pull/16 ), think it makes sense to add it to the global pinnings. Starting with 3 there, but have also added a migrator for 4, which was recently added ( https://github.com/conda-forge/openslide-feedstock/pull/24 ). This will help us step from OpenSlide 3 to 4 (especially as some things like OpenSlide-Python still use 3)