### PR TITLE
Bump `openslide` to `4`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -663,7 +663,7 @@ openjpeg:
 openmpi:
   - 4
 openslide:
-  - 3
+  - 4
 openssl:
   - '3'
 orc:

--- a/recipe/migrations/openslide4.yaml
+++ b/recipe/migrations/openslide4.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for openslide 4
-  kind: version
-  migration_number: 1
-openslide:
-- 4
-migrator_ts: 1706069399


### PR DESCRIPTION
Closes out the `openslide` migration to `4` that was started in PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5415 )

Based on [the migrator status]( 
https://conda-forge.org/status/#openslide4 ) all PRs are merged. Nothing left to do

<img width="777" alt="Screenshot 2024-01-24 at 11 14 26 AM" src="https://github.com/conda-forge/conda-forge-pinning-feedstock/assets/3019665/3977ee16-b966-4e78-97c5-bf73e3072fce">

