### PR TITLE
remove duplicated cuda_compiler_version_min

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -48,7 +48,6 @@ cuda_compiler_version:
 cuda_compiler_version_min:
   - None                       # [osx]
   - 11.2                       # [linux or win64]
-  - 11.8                       # [linux or win64]
 
 arm_variant_type:              # [aarch64]
   - sbsa                       # [aarch64]


### PR DESCRIPTION
https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/7aae3073fffa4fa052d11551102d6c0b65308a95 added a second value for `cuda_compiler_version_min`, but it's not zipped with the rest of the compiler pins, and there should only be one value.

This now causes rerenders of the following kind:
```diff
 cuda_compiler_version:
-- '11.2'
+- '11.8'
 cuda_compiler_version_min:
 - '11.2'
+- '11.8'
```
which are just mismatched.

CC @jakirkham 