### PR TITLE
WIP: Migrate for zlib 1.3?

### DIFF
--- a/recipe/migrations/zlib13.yaml
+++ b/recipe/migrations/zlib13.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+zlib:
+- '1.3'
+migrator_ts: 1706542673.1618695


### PR DESCRIPTION
There was a new zlib build release last August (a few weeks [ago](https://github.com/conda-forge/zlib-feedstock/pull/76) in conda-forge; it seems the bot didn't open a PR yet).

We've been on zlib 1.2 since the beginning of the global pinning
https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/754eda87ebfaec98adae77eebb63d7e7c0452777/recipe/conda_build_config.yaml#L195-L196
so this would probable be a relatively big migration. It's possible that migrating isn't even necessary though. While there's been no update in the [abi lab](https://abi-laboratory.pro/?view=timeline&l=zlib) for a long time, the newest `libzlib` still [contains](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Flibzlib-1.3-hd590300_0.conda) both:
```
lib/libz.so.1
lib/libz.so.1.3
```
indicating that major-level pinning the SOVER should be enough.

The [changelog](https://github.com/madler/zlib/blob/develop/ChangeLog) for zlib 1.3 also doesn't look particularly scary or ABI-relevant, though I guess the minor number was increased due to things like https://github.com/madler/zlib/issues/633, which caused a pretty substantial overhaul, see e.g. https://github.com/madler/zlib/commit/e9d5486e6635141f589e110fd789648aa08e9544

We should check if the ABI changed; if not, we could relax the pins.

CC @conda-forge/zlib @conda-forge/core