### PR TITLE
feat: add r-brms and r-rstanarm to arch_rebuilt.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -574,6 +574,7 @@ r-bindrcpp
 r-bitops
 r-blockmodeling
 r-brglm
+r-brms
 r-cairo
 r-car
 r-catboost
@@ -767,6 +768,7 @@ r-rrcov
 r-rsnns
 r-rspectra
 r-rsqlite
+r-rstanarm
 r-rsvg
 r-rtsne
 r-ruv


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This adds `r-rstanarm` and `r-brms` to be rebuilt for aarch64