### PR TITLE
add combined migration for abseil/grpc/protobuf

### DIFF
--- a/recipe/migrations/libabseil20240116_libgrpc161_libprotobuf4252.yaml
+++ b/recipe/migrations/libabseil20240116_libgrpc161_libprotobuf4252.yaml
@@ -1,0 +1,23 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20240116, libgrp 1.61, libprotobuf 4.25.2
+  kind: version
+  migration_number: 1
+  paused: True
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    # this shouldn't attempt to modify the python feedstocks
+    - protobuf
+libabseil:
+- "20240116"
+libgrpc:
+- "1.61"
+libprotobuf:
+- 4.25.2
+# already covered by libabseil20230802_libgrpc157_libprotobuf4234,
+# which we cannot delete yet, but keep for clarity
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- "10.13"                  # [osx and x86_64]
+migrator_ts: 1705991934.9119136


### PR DESCRIPTION
Combined migration for [libprotobuf v25.2](https://github.com/conda-forge/libprotobuf-feedstock/pull/202), [grpc 1.61](https://github.com/conda-forge/grpc-cpp-feedstock/pull/348) and [abseil 20240116.0](https://github.com/conda-forge/abseil-cpp-feedstock/pull/71).

~Leaving this as a draft until all builds are green~

Closes #5413