### PR TITLE
extra platforms for `r-showtext`

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -785,6 +785,7 @@ r-seurat
 r-sfheaders
 r-sgeostat
 r-shinywidgets
+r-showtext
 r-slam
 r-slider
 r-sm

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1135,6 +1135,7 @@ r-rsvg
 r-s2
 r-seurat
 r-sf
+r-showtext
 r-slider
 r-sn
 r-sodium


### PR DESCRIPTION
ARM64 migrations for `r-showtext`. ([user requested](https://github.com/conda-forge/r-showtext-feedstock/issues/16))

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
