### PR TITLE
add stdlib metapackages to pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,6 +8,15 @@ c_compiler_version:            # [unix]
   - 16                         # [osx]
   - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux]
   - 11                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux]
+c_stdlib:
+  - sysroot                    # [linux]
+  - macosx_deployment_target   # [osx]
+  - vs                         # [win]
+c_stdlib_version:              # [unix]
+  - 2.12                       # [linux64]
+  - 2.17                       # [aarch64 or ppc64le]
+  - 10.9                       # [osx and x86_64]
+  - 11.0                       # [osx and arm64]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
@@ -159,6 +168,9 @@ zip_keys:
   -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  -                             # [unix]
+    - c_stdlib                  # [unix]
+    - c_stdlib_version          # [unix]
   -
     - python
     - numpy


### PR DESCRIPTION
Based on infrastructure from https://github.com/conda/conda-build/issues/4981, using packages from
* https://github.com/conda-forge/linux-sysroot-feedstock/
* https://github.com/conda-forge/osx-sysroot-feedstock/
* https://github.com/conda-forge/vc-feedstock/

This is in the larger context of moving our baseline on MacOS to [10.13](https://github.com/conda-forge/conda-forge.github.io/issues/1844) as soon as feasible and to glibc [2.17](https://github.com/conda-forge/conda-forge.github.io/pull/1980) on linux later this year.

In particular, we should add this to be able to properly test the new setup in https://github.com/regro/conda-forge-feedstock-check-solvable, which got brought up in the context of https://github.com/regro/cf-scripts/pull/2135.