### PR TITLE
bump re2 to 2023.09.01

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -757,7 +757,7 @@ qtkeychain:
 rdma_core:
   - '49'
 re2:
-  - 2023.06.02
+  - 2023.09.01
 readline:
   - "8"
 rocksdb:


### PR DESCRIPTION
This explicitly does _not_ come with a migration, because we re2 now has a SOVER, which hasn't [changed](https://github.com/google/re2/blob/2023-09-01/CMakeLists.txt#L31-L33) from 2023.06.02, and we [refactored](https://github.com/conda-forge/re2-feedstock/issues/67) the re2 outputs so that the `re2` version should just be possible to bump in the pinning _without_ a migration, whereas `libre2-11` reflects the ABI/SOVER (i.e. changes there need a migration).

This is the [first](https://github.com/conda-forge/re2-feedstock/pull/71) version bump after the refactoring, so taking time to double-check here. 

CC @conda-forge/re2