### PR TITLE
start migration for libabseil, libgrpc & libprotobuf

### DIFF
--- a/recipe/migrations/libabseil20240116_libgrpc161_libprotobuf4252.yaml
+++ b/recipe/migrations/libabseil20240116_libgrpc161_libprotobuf4252.yaml
@@ -3,7 +3,6 @@ __migrator:
   commit_message: Rebuild for libabseil 20240116, libgrp 1.61, libprotobuf 4.25.2
   kind: version
   migration_number: 1
-  paused: True
   exclude:
     - abseil-cpp
     - grpc-cpp


### PR DESCRIPTION
Actually switch on migration added in #5460, now that the last blocker is getting solved.

Closes #5474
Closes #5492