### PR TITLE
fix c_stdlib_version zip with cdt_name

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,8 +13,11 @@ c_stdlib:
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
 c_stdlib_version:              # [unix]
-  - 2.12                       # [linux and x86_64]
+  - 2.12                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
+  - 2.17                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
   - 2.17                       # [linux and not x86_64]
+  - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 10.9                       # [osx and x86_64]
   - 11.0                       # [osx and arm64]
 cxx_compiler:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -164,7 +164,6 @@ zip_keys:
     - c_compiler_version        # [unix]
     - cxx_compiler_version      # [unix]
     - fortran_compiler_version  # [unix]
-    - c_stdlib                  # [unix]
     - c_stdlib_version          # [unix]
     - cdt_name                  # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -90,6 +90,9 @@ cxx_compiler_version:          # [linux and os.environ.get("CF_CUDA_ENABLED", "F
 fortran_compiler_version:      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
+c_stdlib_version:              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 cdt_name:                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cos7                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 


### PR DESCRIPTION
Follow-up to #5592

This tries to match the setup of the linux selectors with cdtname:
https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/595a16bb6088c5c90fc7140d15ba5b507c262245/recipe/conda_build_config.yaml#L123-L132

CC @beckermr @jakirkham @isuruf 