### PR TITLE
Remove protobuf and grpcio zip

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -181,12 +181,6 @@ zip_keys:
     - arrow_cpp
     - libarrow
     - libarrow_all
-  # as of 4.23.x, libprotobuf requires patch-level run-exports;
-  # we couple it with grpc (which very roughly releases in sync)
-  # to reduce the migration pain for these two libs a bit.
-  -
-    - libgrpc
-    - libprotobuf
 
 
 # aarch64 specifics because conda-build sets many things to centos 6


### PR DESCRIPTION
@h-vetinari could we remove this zip key, or alternatively, add abseil to it?

I feel like it is giving me trouble with: https://github.com/conda-forge/openvino-feedstock/pull/79

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
