### PR TITLE
Add idyntree to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -409,6 +409,8 @@ hdf5:
   - 1.14.3
 icu:
   - '73'
+idyntree:
+  - '11'
 imath:
   - 3.1.11
 ipopt:


### PR DESCRIPTION
`idyntree` mantains `abi` compatibility for each major version, see https://github.com/conda-forge/idyntree-feedstock/blob/6f8a83b4423b3a8761011e197c54b1d18d004149/recipe/meta.yaml#L16 . There are not a lot of C++ packages currently depending on it (just `libbipedal-locomotion-framework` and `libunicycle-footstep-planner`), however it is convenient to have explicit pinning to ensure that both of them are compiled against compatible versions of iDynTree.

I did not added a migrator for 11 as I just rebuilt both packages that depend on iDynTree to ensure that they were built with the latest iDynTree (see https://github.com/conda-forge/libunicycle-footstep-planner-feedstock/pull/14 and https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/pull/59).


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
