### PR TITLE
Add libyarp to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -633,6 +633,8 @@ libxsmm:
   - 1
 libuuid:
   - 2
+libyarp:
+  - 3.9.0
 libzip:
   - 1
 lmdb:


### PR DESCRIPTION
libyarp  is a shared library with `run_exports` (see https://github.com/conda-forge/yarp-feedstock/blob/594f60a3c77c518c808692ec52765b7571eea038/recipe/meta.yaml#L26) on which more than a package depends ([`librobometry`](https://github.com/conda-forge/librobometry-feedstock/blob/d39899d5ad85ed1310459ba9fd95b81d088a362a/recipe/meta.yaml#L36), [`libbipedal-locomotion-framework`](https://github.com/conda-forge/bipedal-locomotion-framework-feedstock/blob/3fb58b2bd6d432db695df7d2be33553cb867d14a/recipe/meta.yaml#L44), [`libgazebo-yarp-plugins`](https://github.com/conda-forge/gazebo-yarp-plugins-feedstock/blob/4258eb6eda82a40d07840f1573ada25303a25143/recipe/meta.yaml#L38) ). 

All dependent packages have been built to 3.9.0, so there is no need to add a 3.9.0 migration, we can directly pin to 3.9.0 .


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
