### PR TITLE
Add migrator for mysql-devel

### DIFF
--- a/recipe/migrations/mysql_devel83.yaml
+++ b/recipe/migrations/mysql_devel83.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1710446179
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+# Add this to the conda-forge pinning yaml when closing the migrator
+mysql_devel:
+  - '8.3'


### PR DESCRIPTION
It seems to not have existed and is currently pinned for qt-main

@conda-forge/qt-main

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
