### PR TITLE
pin expat 2.5

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -333,7 +333,7 @@ elfutils:
 exiv2:
   - 0.27
 expat:
-  - 2
+  - 2.5
 ffmpeg:
   - '6'
 fftw:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -332,6 +332,11 @@ elfutils:
   - 0.190
 exiv2:
   - 0.27
+# The vtk-feedstock maintainers asked that we pin to 2.5 at build time
+# to help with compatibility with their packages
+# while they resolve the underlying issue upstream
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5640
+# The pin may be reverted to '2' in June 2024.
 expat:
   - 2.5
 ffmpeg:


### PR DESCRIPTION
vtk, at least, won't run with expat 2.6, so keep building packages with expat 2.5 for now

alternative:

- don't do this, and let vtk be incompatible with other expat-linking packages built after last week's release of expat 2.6 until we get a patch for https://gitlab.kitware.com/vtk/vtk/-/issues/19258

expat 2.5 has run_exports `>=2.5,<3`, so 2.6 will still be used at _runtime_, which I understand to be correct _in general_, despite an incompatibility (not ABI-related) with 2.6 that has come up in vtk in particular.

xref:

- https://github.com/conda-forge/vtk-feedstock/pull/321
- https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/682