### PR TITLE
Add libode to pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -565,6 +565,8 @@ libmicrohttpd:
   - '1.0'
 libnetcdf:
   - 4.9.2
+libode:
+  - 0.16.2
 libopencv:
   - 4.9.0
 libopentelemetry_cpp:


### PR DESCRIPTION
libode is a shared library with `run_exports` (see https://github.com/conda-forge/libode-feedstock/blob/387abf118bd3b30968c25c2f8678ab431f31a91c/recipe/meta.yaml#L25) on which more than a package depends.

0.16.2 has been released 4 years ago, so I think we do not need a 0.16.2 migrator (https://github.com/conda-forge/libode-feedstock/pull/2).



Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
