### PR TITLE
Request migration of mcpl and ncrystal to linux-aarch64 

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -353,6 +353,7 @@ manim
 mariadb-connector-c
 mathjax
 matplotlib
+mcpl
 mdtraj
 meilisearch
 memray
@@ -382,6 +383,7 @@ ncbi-datasets-cli
 nccl
 ncdu
 ncurses
+ncrystal
 nds2-client-swig
 neobolt
 newrelic

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -382,8 +382,8 @@ nbgrader
 ncbi-datasets-cli
 nccl
 ncdu
-ncurses
 ncrystal
+ncurses
 nds2-client-swig
 neobolt
 newrelic


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Ment to eventually enable both of the feedstocks for mcstas and mcxtrace for linux-aarch64
https://github.com/conda-forge/mcstas-suite-feedstock (mcpl, ncrystal are dependencies)
https://github.com/conda-forge/mcxtrace-suite-feedstock (mcpl is dependency)
