### PR TITLE
Add pulseaudio-client to the migration

### DIFF
--- a/recipe/migrations/pulseaudio17.yaml
+++ b/recipe/migrations/pulseaudio17.yaml
@@ -6,3 +6,7 @@ __migrator:
 migrator_ts: 1705695822.065136
 pulseaudio:
 - '17'
+pulseaudio-client:
+- '17'
+pulseaudio-daemon:
+- '17'

--- a/recipe/migrations/pulseaudio17.yaml
+++ b/recipe/migrations/pulseaudio17.yaml
@@ -6,7 +6,7 @@ __migrator:
 migrator_ts: 1705695822.065136
 pulseaudio:
 - '17'
-pulseaudio-client:
+pulseaudio_client:
 - '17'
-pulseaudio-daemon:
+pulseaudio_daemon:
 - '17'


### PR DESCRIPTION
Some packages (qt5-main) have started to explicitely depend on pulseaudio-client (licensed differently than daemon)


Do i need to bump the number of the migrator? i think the old migrations are fine.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
