### PR TITLE
Add miration and global pin for c-blosc2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -296,6 +296,8 @@ bzip2:
   - 1
 c_ares:
   - 1
+c_blosc2:
+  - '2.13'
 cairo:
   - 1
 capnproto:

--- a/recipe/migrations/cblosc2214.yaml
+++ b/recipe/migrations/cblosc2214.yaml
@@ -5,4 +5,4 @@ __migrator:
   bump_number: 1
 
 c_blosc2:
-  - '2.14'
+  - '2.14.4'

--- a/recipe/migrations/cblosc2214.yaml
+++ b/recipe/migrations/cblosc2214.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1712842415
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+c_blosc2:
+  - '2.14'


### PR DESCRIPTION
Larger discussion in: https://github.com/conda-forge/c-blosc2-feedstock/issues/62#issuecomment-2049675391

TLDR:

- Previous run export was to major version
- SO changed in between 2.13 and 2.14

Patching will be made for previous builds in https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/703

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
