### PR TITLE
Revert "also set c_stdlib_version on windows"

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ c_stdlib:
   - sysroot                    # [linux]
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
-c_stdlib_version:
+c_stdlib_version:              # [unix]
   - 2.12                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
   - 2.17                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
   - 2.17                       # [linux and not x86_64]
@@ -20,8 +20,6 @@ c_stdlib_version:
   - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 10.9                       # [osx and x86_64]
   - 11.0                       # [osx and arm64]
-  - 2019                       # [win and x86_64]
-  - 2022                       # [win and arm64]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]


### PR DESCRIPTION
This reverts commit 47186b20cda45fabf5ea6a307cbcb7f41a984485.

This was added to unbreak various builds that ended up pulling both vs2019 & vs2022 (see [discussion](https://github.com/conda-forge/conda-forge.github.io/issues/2102)), though the underlying issue was actually in the [vs setup](https://github.com/conda-forge/vc-feedstock/pull/75), which got [fixed](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/701) in repodata.

Now that constraint is leading to different [breakage](https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/86) for `vs2022` users, who suddenly need to update their `c_stdlib_version`, or get a resolution error:
```
Getting pinned dependencies: ...working... failed
WARNING: failed to get package records, retrying.  exception was: Unsatisfiable dependencies for platform win-64: {MatchSpec("vs_win-64==2019.11=he1865b1_12")}
Encountered problems while solving:
  - package vs2022_win-64-19.33.31629-hc4b314a_8 has constraint vs_win-64 2022.* conflicting with vs_win-64-2019.11-he1865b1_12
```

Given the repodata fix is in place, I think we should revert the `c_stdlib_version` for windows here (it's also not consistently set between `c_compiler` being `vs2022` and `c_stdlib_version` using bare `2022`). We might want to wait for https://github.com/conda-forge/vc-feedstock/pull/75 though.