### PR TITLE
Close flatbuffers2436

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -347,7 +347,7 @@ fftw:
 flann:
   - 1.9.2
 flatbuffers:
-  - 23.5.26
+  - 24.3.6
 fmt:
   - '10'
 fontconfig:

--- a/recipe/migrations/flatbuffers2436.yaml
+++ b/recipe/migrations/flatbuffers2436.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for flatbuffers 24.3.6
-  kind: version
-  migration_number: 1
-flatbuffers:
-- 24.3.6
-migrator_ts: 1709816173.0728629


### PR DESCRIPTION
Everything except @conda-forge/tensorflow and dependencies migrated. Tensorflow will probably jump directly to the next version.