### PR TITLE
Add geoarrow-c to aarch and arm-osx-64 migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -189,6 +189,7 @@ functools32
 gds-swig
 geant4
 geckodriver
+geoarrow-c
 geohexviz
 geopandas
 gevent

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -349,6 +349,7 @@ gemmi
 genesis4
 genshi
 gensim
+geoarrow-c
 geocat-comp
 geocat-f2py
 geohexviz


### PR DESCRIPTION
Kicking off aarch64, ppc64le and arm-osx builds for [geoarrow-c](https://github.com/geoarrow/geoarrow-c).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
