### PR TITLE
numpy 2.0.0rc migration

### DIFF
--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -1,7 +1,32 @@
 __migrator:
   build_number: 1
   kind: version
-  commit_message: "Rebuild for numpy 2.0"
+  commit_message: |
+    Rebuild for numpy 2.0
+    
+    As of version 2.0, the way we build against numpy has changed. In particular,
+    we no longer need to use the oldest available numpy version at build time
+    in order to support old numpy version at runtime - numpy will by default
+    use a compatible ABI for the oldest still-supported numpy versions.
+    
+    Additionally, we no longer need to use `{{ pin_compatible("numpy") }}` as a
+    run requirement - this has been handled for more than two years now by a
+    run-export on the numpy package itself. The migrator will therefore remove
+    any occurrences of this.
+    
+    However, by default, building against numpy 2.0 will assume that the package
+    is compatible with numpy 2.0, which is not necessarily the case. You should
+    check that the upstream package explicitly supports numpy 2.0, otherwise you
+    need to add a `- numpy <2` run requirement until that happens (check numpy
+    issue 26191 for an overview of the most important packages).
+    
+    Finally, numpy 2.0 has not yet been released, but there is a release candidate
+    that promises to be ABI-compatible with the final release. This means we can
+    build against numpy 2.0.0rc1 (which can only be installed using a special channel
+    to opt in, i.e. `conda install -c conda-forge/label/numpy_rc numpy=2.0`), and yet
+    produce packages that are compatible with older numpy versions and therefore can
+    be published to our main channels.
+
   migration_number: 1
   ordering:
   # prefer channels including numpy_rc (otherwise smithy doesn't

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -25,10 +25,10 @@ __migrator:
     need to add a `- numpy <2` run requirement until that happens (check numpy
     issue 26191 for an overview of the most important packages).
     
-    Finally, numpy 2.0 has not yet been released, but there is a release candidate
-    that promises to be ABI-compatible with the final release. This means we can
-    build against numpy 2.0.0rc1, and yet produce packages that are compatible
-    with older numpy versions and therefore can be published to our main channels.
+    Note that the numpy release candidate promises to be ABI-compatible with the
+    final 2.0 release. This means that building against 2.0.0rc1 produces packages
+    that can be published to our main channels.
+    
     If you already want to use the numpy 2.0 release candidate yourself, you can do
     ```
     conda config --add channels conda-forge/label/numpy_rc

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -36,7 +36,10 @@ __migrator:
     or add this channel to your `.condarc` file directly.
     
     To-Dos:
-      * [ ] Confirm upstream package is compatible with numpy 2.0, or add `numpy <2` upper bound in `run`.
+      * [ ] Match run-requirements for numpy (i.e. check upstream `pyproject.toml` or however the project specifies numpy compatibility)
+        * If upstream is not yet compatible with numpy 2.0, add `numpy <2` upper bound under `run:`.
+        * If upstream is already compatible with numpy 2.0, nothing else should be necessary in most cases.
+        * If upstream requires a minimum numpy version newer than 1.19, you can add `numpy >=x.y` under `run:`.
       * [ ] Remove any remaining occurrences of `{{ pin_compatible("numpy") }}` that the bot may have missed.
     
     PS. If the build does not compile anymore, this is almost certainly a sign that

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -5,13 +5,9 @@ __migrator:
   migration_number: 1
 
 # needs to fully reproduce zip of {python, python_impl, numpy}
-# in order to build for 2.0 and the 1.x per python version
+# in order to override it
 numpy:
-  - 1.22
-  - 1.22
-  - 1.22
-  - 1.23
-  - 2.0
+  - 1.22  # no py38 support for numpy 2.0
   - 2.0
   - 2.0
   - 2.0
@@ -20,15 +16,7 @@ python:
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
-  - 3.8.* *_cpython
-  - 3.9.* *_cpython
-  - 3.10.* *_cpython
-  - 3.11.* *_cpython
 python_impl:
-  - cpython
-  - cpython
-  - cpython
-  - cpython
   - cpython
   - cpython
   - cpython

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -4,10 +4,15 @@ __migrator:
   commit_message: |
     Rebuild for numpy 2.0
     
-    As of version 2.0, the way we build against numpy has changed. In particular,
-    we no longer need to use the oldest available numpy version at build time
-    in order to support old numpy version at runtime - numpy will by default
-    use a compatible ABI for the oldest still-supported numpy versions.
+    TL;DR: The way we build against numpy has changed as of numpy 2.0. This bot
+    PR has updated the recipe to account for the changes (see below for details).
+    The numpy 2.0 package itself is currently only available from a special release
+    channel (`conda-forge/label/numpy_rc`) and will not be available on the main
+    `conda-forge` channel until the release of numpy 2.0 GA.
+    
+    The biggest change is that we no longer need to use the oldest available numpy
+    version at build time in order to support old numpy version at runtime - numpy
+    will by default use a compatible ABI for the oldest still-supported numpy versions.
     
     Additionally, we no longer need to use `{{ pin_compatible("numpy") }}` as a
     run requirement - this has been handled for more than two years now by a
@@ -22,10 +27,23 @@ __migrator:
     
     Finally, numpy 2.0 has not yet been released, but there is a release candidate
     that promises to be ABI-compatible with the final release. This means we can
-    build against numpy 2.0.0rc1 (which can only be installed using a special channel
-    to opt in, i.e. `conda install -c conda-forge/label/numpy_rc numpy=2.0`), and yet
-    produce packages that are compatible with older numpy versions and therefore can
-    be published to our main channels.
+    build against numpy 2.0.0rc1, and yet produce packages that are compatible
+    with older numpy versions and therefore can be published to our main channels.
+    If you already want to use the numpy 2.0 release candidate yourself, you can do
+    ```
+    conda config --add channels conda-forge/label/numpy_rc
+    ```
+    or add this channel to your `.condarc` file directly.
+    
+    To-Dos:
+      * [ ] Confirm upstream package is compatible with numpy 2.0, or add `numpy <2` upper bound in `run`.
+      * [ ] Remove any remaining occurrences of `{{ pin_compatible("numpy") }}` that the bot may have missed.
+    
+    PS. If the build does not compile anymore, this is almost certainly a sign that
+    the upstream project is not yet ready for numpy 2.0; do not close this PR until
+    a version compatible with numpy 2.0 has been released upstream and on this
+    feedstock (in the meantime, you can keep the bot from reopening this PR in
+    case of git conflicts by marking it as a draft).
 
   migration_number: 1
   ordering:

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -35,7 +35,7 @@ __migrator:
     ```
     or add this channel to your `.condarc` file directly.
     
-    To-Dos:
+    ### To-Dos:
       * [ ] Match run-requirements for numpy (i.e. check upstream `pyproject.toml` or however the project specifies numpy compatibility)
         * If upstream is not yet compatible with numpy 2.0, add `numpy <2` upper bound under `run:`.
         * If upstream is already compatible with numpy 2.0, nothing else should be necessary in most cases.

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -3,6 +3,12 @@ __migrator:
   kind: version
   commit_message: "Rebuild for numpy 2.0"
   migration_number: 1
+  ordering:
+  # prefer channels including numpy_rc (otherwise smithy doesn't
+  # know which of the two values should be taken on merge)
+  channel_sources:
+    - conda-forge
+    - conda-forge/label/numpy_rc,conda-forge
 
 # needs to fully reproduce zip of {python, python_impl, numpy}
 # in order to override it
@@ -22,5 +28,5 @@ python_impl:
   - cpython
   - cpython
 channel_sources:
-  - conda-forge/label/numpy_dev,conda-forge
+  - conda-forge/label/numpy_rc,conda-forge
 migrator_ts: 1713572489.295986

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -1,0 +1,38 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for numpy 2.0"
+  migration_number: 1
+
+# needs to fully reproduce zip of {python, python_impl, numpy}
+# in order to build for 2.0 and the 1.x per python version
+numpy:
+  - 1.22
+  - 1.22
+  - 1.22
+  - 1.23
+  - 2.0
+  - 2.0
+  - 2.0
+  - 2.0
+python:
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+channel_sources:
+  - conda-forge/label/numpy_dev,conda-forge
+migrator_ts: 1713572489.295986

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -34,8 +34,11 @@ __migrator:
 
 python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
+  - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.22               # [not (osx and arm64)]
+  - 2.0                # [not (osx and arm64)]
 python_impl:
+  - pypy               # [not (osx and arm64)]
   - pypy               # [not (osx and arm64)]

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -36,8 +36,6 @@ python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 2.0                # [not (osx and arm64)]
+  - 1.22               # [not (osx and arm64)]
 python_impl:
   - pypy               # [not (osx and arm64)]
-channel_sources:
-  - conda-forge/label/numpy_rc,conda-forge  # [not (osx and arm64)]

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -40,4 +40,4 @@ numpy:
 python_impl:
   - pypy               # [not (osx and arm64)]
 channel_sources:
-  - conda-forge/label/numpy_dev,conda-forge  # [not (osx and arm64)]
+  - conda-forge/label/numpy_rc,conda-forge  # [not (osx and arm64)]

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -34,11 +34,10 @@ __migrator:
 
 python:
   - 3.9.* *_73_pypy    # [not (osx and arm64)]
-  - 3.9.* *_73_pypy    # [not (osx and arm64)]
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.22               # [not (osx and arm64)]
   - 2.0                # [not (osx and arm64)]
 python_impl:
   - pypy               # [not (osx and arm64)]
-  - pypy               # [not (osx and arm64)]
+channel_sources:
+  - conda-forge/label/numpy_dev,conda-forge  # [not (osx and arm64)]

--- a/recipe/migrations/python312.yaml
+++ b/recipe/migrations/python312.yaml
@@ -31,8 +31,11 @@ __migrator:
 
 python:
   - 3.12.* *_cpython
+  - 3.12.* *_cpython
 # additional entries to add for zip_keys
 numpy:
   - 1.26
+  - 2.0
 python_impl:
+  - cpython
   - cpython

--- a/recipe/migrations/python312.yaml
+++ b/recipe/migrations/python312.yaml
@@ -31,11 +31,10 @@ __migrator:
 
 python:
   - 3.12.* *_cpython
-  - 3.12.* *_cpython
 # additional entries to add for zip_keys
 numpy:
-  - 1.26
   - 2.0
 python_impl:
   - cpython
-  - cpython
+channel_sources:
+  - conda-forge/label/numpy_dev,conda-forge

--- a/recipe/migrations/python312.yaml
+++ b/recipe/migrations/python312.yaml
@@ -37,4 +37,4 @@ numpy:
 python_impl:
   - cpython
 channel_sources:
-  - conda-forge/label/numpy_dev,conda-forge
+  - conda-forge/label/numpy_rc,conda-forge


### PR DESCRIPTION
This follows https://github.com/conda-forge/conda-forge.github.io/issues/1997 & discussion in core this week.

<details>
<summary>Previously...</summary>

There are a couple of problems, most of which stem from the existing zip between `{numpy, python, python_impl}`. Due to this zip, wanting to build for both numpy 1.x & numpy 2.0 means we have to duplicate all keys involved in the zip. I've been testing this on the scipy-feedstock, see https://github.com/conda-forge/scipy-feedstock/pull/274/commits/5c8599dbcaa6cee81867f38193f518ecaa887b4a.

However, the immediate problems that arise are:
* `channel_sources` does not get populated correctly despite being update in the migrator (am I missing something...?)
* migrations with `operation: key_add` can apparently only add _one_ key, so - after the necessary duplication due to the zip - the changes in `python312.yaml` and `pypy38.yaml` end up dropping the existing 1.x builds
* using `additional_zip_keys: channel_sources` (like for python [3.12.0rc](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4914)) leads to `RecursionError: maximum recursion depth exceeded` in smithy (see https://github.com/conda-forge/scipy-feedstock/pull/274/commits/22d530f32cabbc22b8316cb6e35e344c04d4f767).

</details>

After discussion in that issue, it seems we're tending towards not dealing with duplicating all numpy builds into 1.x & 2.0rc1, but rather building everything against 2.0rc1 directly (problems with that outlined below).

However, one issue from the original approach still remains:
> `channel_sources` does not get populated correctly despite being update in the migrator (am I missing something...?)

Despite setting `channel_sources` in the migrators unequivocally, it ends up getting ignored by conda-smithy. I have a local smithy fix that I'm testing in https://github.com/conda-forge/scipy-feedstock/pull/274 together with the migrator state from this PR.


