### PR TITLE
Close out c-blosc2 2.14 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -295,7 +295,7 @@ bzip2:
 c_ares:
   - 1
 c_blosc2:
-  - '2.13'
+  - '2.14'
 cairo:
   - 1
 capnproto:

--- a/recipe/migrations/c_blosc2214.yaml
+++ b/recipe/migrations/c_blosc2214.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for c_blosc2 2.14
-  kind: version
-  migration_number: 1
-c_blosc2:
-- '2.14.4'
-migrator_ts: 1712872025.701592


### PR DESCRIPTION
xref: https://github.com/conda-forge/c-blosc2-feedstock/issues/62

I had pinnined to 2.14.4 to avoid problematic versions.

Things should be good now

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
