### PR TITLE
Add Tracktable to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1408,6 +1408,7 @@ torchsde
 torchsparse
 torchtext
 torchvision
+tracktable
 traits
 treecorr
 treelite


### PR DESCRIPTION
Tracktable is ready to be added to the arm64 builds.  We've been building and distributing arm64 wheels via PyPI for a while now and we're confident that things are stable, though we're always prepared for a few conda-specific quirks.

