### PR TITLE
Close ipopt31415 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -420,7 +420,7 @@ idyntree:
 imath:
   - 3.1.11
 ipopt:
-  - 3.14.14
+  - 3.14.15
 isl:
   - '0.26'
 jasper:

--- a/recipe/migrations/ipopt31415.yaml
+++ b/recipe/migrations/ipopt31415.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for ipopt 3.14.15
-  kind: version
-  migration_number: 1
-ipopt:
-- 3.14.15
-migrator_ts: 1712831185.5957112


### PR DESCRIPTION
Only two feedstocks are missing (see https://conda-forge.org/status/migration/ipopt31415):
* openturns (where the mantainer suggested to wait for the ipopt31416 migration instead, see https://github.com/conda-forge/openturns-feedstock/pull/206#issuecomment-2068855623)
* biorbd, that is currently failing with a Not solvable error

In any case, I think it is safe to close the 3.14.15 migration and start the 31416 one (see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5796).

fyi @conda-forge/ipopt @conda-forge/openturns @conda-forge/biorbd 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
