### PR TITLE
increase minimum macOS deployment target to 10.13

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -16,7 +16,7 @@ c_stdlib_version:              # [unix]
   - 2.17                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
   - 2.17                       # [linux and not x86_64]
   - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 10.9                       # [osx and x86_64]
+  - 10.13                      # [osx and x86_64]
   - 11.0                       # [osx and arm64]
 cxx_compiler:
   - gxx                        # [linux]
@@ -103,7 +103,7 @@ macos_machine:                 # [osx]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 11.0                       # [osx and arm64]
-  - 10.9                       # [osx and x86_64]
+  - 10.13                      # [osx and x86_64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -98,6 +98,10 @@ target_gobin:
 rust_compiler:
   - rust
 
+# the numbers here are the Darwin Kernel version for macOS 10.9 & 11.0;
+# this is used to form our target triple on osx, and nothing else. After
+# we bumped the minimum macOS version to 10.13, this was left unchanged,
+# since it is not essential, and long-term we'd like to remove the version.
 macos_machine:                 # [osx]
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]


### PR DESCRIPTION
This tiny change has been a long time coming, for a taste of the journey check out:
* https://github.com/conda-forge/conda-forge.github.io/issues/2102
* https://github.com/conda-forge/conda-forge.github.io/issues/1844

Closes https://github.com/conda-forge/conda-forge.github.io/issues/1844

We've already [announced](https://conda-forge.org/news/2023/08/24/bumping-minimum-macos-version-to-1013/) the move last August, but needed a whole bunch of new functionality to make things work.

I proposed in the core call just now to do this separately for macOS (as we've promised to move to glibc 2.17 on linux in June, and this will probably be an even bigger change), so that we get to test it in real life, and also since all the prerequisites are there now.

In particular, feedstocks that haven't yet been touched by the stdlib-piggyback migrator (which will keep running; it adds the required `{{ stdlib("c") }}` to the recipes whenever a migrator or version bump comes by) will now get a linter warning to add it (as of conda-smithy 3.35), so that a warning-free feedstock will continue to produce correct artefacts. This was what had been [agreed](https://github.com/conda-forge/conda-forge.github.io/blob/main/community/minutes/2024-04-17.md?plain=1#L57) in the last core call, and people were fine to bump this in the core call just now as well.

Still, CC @conda-forge/core if anyone has input. Otherwise I'll merge this in ~48h.