### PR TITLE
add definition of m2w64_c_stdlib on windows

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,6 +11,8 @@ c_stdlib:
   - sysroot                    # [linux]
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
+m2w64_c_stdlib:                # [win]
+  - m2w64-toolchain            # [win]
 c_stdlib_version:              # [unix]
   - 2.12                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
   - 2.17                       # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]


### PR DESCRIPTION
As [suggested](https://github.com/conda-forge/r-base-feedstock/pull/297#discussion_r1586291266) by @isuruf. Compiler comes from [here](https://github.com/conda-forge/toolchain-feedstock).

I don't know if this needs a corresponding `m2w64_c_stdlib_version`, please advise.