### PR TITLE
BUG numpy2 channel_sources ordering not indented properly

### DIFF
--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -50,11 +50,11 @@ __migrator:
 
   migration_number: 1
   ordering:
-  # prefer channels including numpy_rc (otherwise smithy doesn't
-  # know which of the two values should be taken on merge)
-  channel_sources:
-    - conda-forge
-    - conda-forge/label/numpy_rc,conda-forge
+    # prefer channels including numpy_rc (otherwise smithy doesn't
+    # know which of the two values should be taken on merge)
+    channel_sources:
+      - conda-forge
+      - conda-forge/label/numpy_rc,conda-forge
 
 # needs to match length of zip {python, python_impl, numpy}
 # as it is in global CBC in order to override it


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@h-vetinari @jakirkham The solver errors and lack of channel sources is due to a bug in the migrator. The channel sources block was not indented properly.
