### PR TITLE
Add ffmpeg7 migration (and keep ffmpeg6 too for now)

### DIFF
--- a/recipe/migrations/ffmpeg7.yaml
+++ b/recipe/migrations/ffmpeg7.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1714874572
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+# 2024/05/04 -- hmaarrfk
+# ffmpeg migrations typically take a long time
+# Initially we ask that projects build out for both ffmpeg 6 and 7
+ffmpeg:
+  - '6'
+  - '7'


### PR DESCRIPTION
I ask that we migrate FFMPEG to 7 while keeping a build for ffmpeg6 while some larger packages have migrated.




<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
