### PR TITLE
also migrate python 3.12 for numpy 2.0; "soft-close" 3.12 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -694,6 +694,7 @@ numpy:
   - 1.22
   - 1.22
   - 1.23
+  - 1.26
 occt:
   - 7.7.2
 openblas:
@@ -764,8 +765,10 @@ python:
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -56,28 +56,14 @@ __migrator:
       - conda-forge
       - conda-forge/label/numpy_rc,conda-forge
 
-# we need to override the entire zip {python, python_impl, numpy}
-# in order to change the length of it; that's the only way to migrate
-# python 3.12 for numpy 2.0, as we cannot update the existing 3.12
-# migrator without breaking already-migrated feedstocks immediately.
+# needs to match length of zip {python, python_impl, numpy}
+# as it is in global CBC in order to override it
 numpy:
   - 1.22  # no py38 support for numpy 2.0
   - 2.0
   - 2.0
   - 2.0
   - 2.0
-python:
-  - 3.8.* *_cpython
-  - 3.9.* *_cpython
-  - 3.10.* *_cpython
-  - 3.11.* *_cpython
-  - 3.12.* *_cpython
-python_impl:
-  - cpython
-  - cpython
-  - cpython
-  - cpython
-  - cpython
 channel_sources:
   - conda-forge/label/numpy_rc,conda-forge
 migrator_ts: 1713572489.295986

--- a/recipe/migrations/numpy2.yaml
+++ b/recipe/migrations/numpy2.yaml
@@ -49,7 +49,6 @@ __migrator:
     case of git conflicts by marking it as a draft).
 
   migration_number: 1
-  paused: true
   ordering:
     # prefer channels including numpy_rc (otherwise smithy doesn't
     # know which of the two values should be taken on merge)
@@ -57,13 +56,28 @@ __migrator:
       - conda-forge
       - conda-forge/label/numpy_rc,conda-forge
 
-# needs to match length of zip {python, python_impl, numpy}
-# as it is in global CBC in order to override it
+# we need to override the entire zip {python, python_impl, numpy}
+# in order to change the length of it; that's the only way to migrate
+# python 3.12 for numpy 2.0, as we cannot update the existing 3.12
+# migrator without breaking already-migrated feedstocks immediately.
 numpy:
   - 1.22  # no py38 support for numpy 2.0
   - 2.0
   - 2.0
   - 2.0
+  - 2.0
+python:
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.12.* *_cpython
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
 channel_sources:
   - conda-forge/label/numpy_rc,conda-forge
 migrator_ts: 1713572489.295986

--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -11,6 +11,7 @@ __migrator:
       - 3.9.* *_cpython
       - 3.10.* *_cpython
       - 3.11.* *_cpython
+      - 3.12.* *_cpython
       - 3.6.* *_73_pypy
       - 3.7.* *_73_pypy
       - 3.8.* *_73_pypy


### PR DESCRIPTION
Otherwise we'll need another migration just for 3.12, which is even more of a hassle than dealing with superfluous migrator PRs now. For more details/discussion, see https://github.com/conda-forge/conda-forge.github.io/issues/1997