### PR TITLE
WIP: start migration for grpc 1.63 & protobuf 5.26.1

### DIFF
--- a/recipe/migrations/libgrpc163_libprotobuf5261.yaml
+++ b/recipe/migrations/libgrpc163_libprotobuf5261.yaml
@@ -2,7 +2,6 @@ __migrator:
   build_number: 1
   commit_message: Rebuild for libgrp 1.63 & libprotobuf 5.26.1
   kind: version
-  paused: true
   migration_number: 1
 libgrpc:
 - "1.63"


### PR DESCRIPTION
#5695 was merged as paused so we can easily build the prerequisites for starting the migration. Unfortunately those will probably take a while, because we need to switch `protobuf` builds to bazel, which will be a pain
* [x] https://github.com/conda-forge/libprotobuf-feedstock/pull/215
* [x] https://github.com/conda-forge/grpc-cpp-feedstock/pull/365
* [x] https://github.com/conda-forge/singlejar-feedstock/pull/83
* [x] https://github.com/conda-forge/grpc_java_plugin-feedstock/pull/83
* [ ] https://github.com/conda-forge/bazel-feedstock/pull/240
* [ ] https://github.com/conda-forge/protobuf-feedstock/pull/215

Opening PR for visibility. 