### PR TITLE
Revert "Add aarch64 build for yaggo"

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -1052,7 +1052,6 @@ xtensor-blas
 xtensor-fftw
 xtensor-io
 xwebrtc
-yaggo
 yarp
 yoda
 yt


### PR DESCRIPTION
Reverts conda-forge/conda-forge-pinning-feedstock#5853

yaggo is a Bioconda recipe. There is no feedstock for it!