### PR TITLE
Add healpix to osx_arm64

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -450,6 +450,7 @@ hdf5
 hdf5-external-filter-plugins
 hdf5plugin
 hdmedians
+healpix
 healpix_cxx
 healpy
 heat


### PR DESCRIPTION
Adding a osx_arm64 entry for healpix, as per https://github.com/conda-forge/healpix-feedstock/pull/5#issuecomment-2100404785.