### PR TITLE
WIP: add github_actions_labels to compiler-zip for CUDA builds

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -134,7 +134,7 @@ cdt_name:  # [linux]
   - cos7   # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 docker_image:                                   # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
-  # Native builds
+  # non-CUDA builds
   - quay.io/condaforge/linux-anvil-cos7-x86_64  # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-aarch64      # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
   - quay.io/condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
@@ -148,6 +148,13 @@ docker_image:                                   # [os.environ.get("BUILD_PLATFOR
   # CUDA 11.8 arch: cross-compilation (build != target)
   - quay.io/condaforge/linux-anvil-cuda:11.8              # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-cuda:11.8              # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+
+# for feedstocks building with cirun, the GHA labels need to be controllable
+# (e.g for CUDA vs. non-CUDA) like docker_image; we add it to the zip here
+# so it can be overridden per feedstock (which also need to set the content).
+github_actions_labels:  # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  - ''                  # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  - ''                  # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 zip_keys:
   # For CUDA, c_stdlib_version/cdt_name is zipped below with the compilers.
@@ -163,6 +170,7 @@ zip_keys:
     - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+    - github_actions_labels     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
   -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/recipe/migrations/cuda120.yaml
+++ b/recipe/migrations/cuda120.yaml
@@ -96,6 +96,9 @@ c_stdlib_version:              # [linux and os.environ.get("CF_CUDA_ENABLED", "F
 cdt_name:                      # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - cos7                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
+github_actions_labels:         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - ''                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 docker_image:                                      # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - quay.io/condaforge/linux-anvil-cos7-x86_64     # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   # case: native compilation (build == target)


### PR DESCRIPTION
This is a draft for discussion to solve a problem in https://github.com/conda-forge/pytorch-cpu-feedstock/pull/238.

In general, for cirun-enabled feedstocks, we need to distinguish the GHA runner in the same way that we need to distinguish the docker_images (mostly CUDA vs. non-CUDA). However, that's basically impossible to pull off in a local CBC, because it would need to add to the zip containing `cuda_compiler`, which isn't possible. The only way I currently see to fix this is to add the key here, but leave it empty, for feedstocks to override.