### PR TITLE
Update libavif pinning (make less strict)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -457,7 +457,7 @@ libarrow_all:
   - 14
   - 13
 libavif:
-  - '1.0.1'
+  - 1
 libblitz:
   - 1.0.2
 libboost_devel:


### PR DESCRIPTION
Channel pinning lags behind latest release of libavif (1.0.4); pinning probably never needed to be so strict. The libavif package exports are setup to prevent ABI breaks by exporting a soname package instead of  the API package, so pinning loosely to the major API version should be safe to do.

A migration is not needed because this pinning update is compatible with the previous pinning. The previous pinning is 1.0.1 and we have not published a 1.0.0 packge. Any >=1,<2 package should be compatible with 1.0.1.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Resolves https://github.com/conda-forge/libavif-feedstock/issues/32

<!--
Please add any other relevant info below:
-->
