### PR TITLE
Add 'nanoarrow' to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -709,6 +709,7 @@ mysql-connector-odbc
 mysql-connector-python
 mysqlclient
 namaster
+nanoarrow
 nanoflann
 nasm
 natcap.invest


### PR DESCRIPTION
Apologies if this isn't the right place to do this...I followed the instructions [here](https://conda-forge.org/docs/maintainer/knowledge_base/). Basically, I am trying to get osx/arm64 builds for the [nanoarrow feedstock](https://github.com/conda-forge/nanoarrow-feedstock).


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
