### PR TITLE
Add `qpdf` to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -782,6 +782,8 @@ pyqtwebengine:
   - 5.15
 pyqtchart:
   - 5.15
+qpdf:
+  - 11
 qt:
   - 5.15
 qt_main:


### PR DESCRIPTION
Add `qpdf` to global pinnings as it wasn't here previously.

Looking at [the history of API/ABI compatibility of `qpdf`]( https://abi-laboratory.pro/index.php?view=timeline&l=qpdf ), it appears that a major pin is probably sufficient with a tight minor pin.

Start with the current version `11`.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/qpdf-feedstock/issues/42