### PR TITLE
Close pcl 1.14.1 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -728,7 +728,7 @@ pango:
 pari:
   - 2.15.* *_pthread
 pcl:
-  - 1.14.0
+  - 1.14.1
 perl:
   - 5.32.1
 petsc:

--- a/recipe/migrations/pcl1141.yaml
+++ b/recipe/migrations/pcl1141.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for pcl 1.14.1
-  kind: version
-  migration_number: 1
-migrator_ts: 1716101838.8134322
-pcl:
-- 1.14.1


### PR DESCRIPTION
It seems that the only thing that is left is freecad which is getting alot of its stuff migrated soon:

https://github.com/conda-forge/freecad-feedstock/pull/122

The rest of the migration seems complete:
https://conda-forge.org/status/migration/pcl1141

Thoughts @looooo @conda-forge/pcl ???

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
