### PR TITLE
Loosene pango pinning from 1.50 to 1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -726,7 +726,7 @@ openssl:
 orc:
   - 2.0.1
 pango:
-  - 1.50
+  - '1'
 pari:
   - 2.15.* *_pthread
 pcl:


### PR DESCRIPTION
It seems that pango run_exports only to the major version

https://github.com/conda-forge/pango-feedstock/blob/main/recipe/meta.yaml#L18

I noticed this since I was tracking the harfbuzz9 migration

* https://github.com/conda-forge/librsvg-feedstock/pull/115
* https://github.com/conda-forge/gtk4-feedstock/pull/55

xref: https://github.com/conda-forge/pango-feedstock/pull/76

cc: @conda-forge/pango 
cc: @conda-forge/harfbuzz

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
