### PR TITLE
Revert "Request aarch64 & arm64 migrations for bellmans-gapc"

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -38,7 +38,6 @@ bayes-filters-lib
 bayeswave
 bazel
 bcrypt
-bellmans-gapc
 bilby.cython
 binaryen
 bindensity

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -77,7 +77,6 @@ bazel
 bc
 bcolz
 bedtools
-bellmans-gapc
 benchmark
 bfg
 bilby.cython


### PR DESCRIPTION
Reverts conda-forge/conda-forge-pinning-feedstock#6166

It was my mistake that bellmans-gaps is a conda-forge feedstock. It is a Bioconda recipe! Apologies!