### PR TITLE
Add `r-gstat` to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -721,6 +721,7 @@ r-glmmtmb
 r-gnm
 r-grbase
 r-grf
+r-gstat
 r-gsw
 r-gtools
 r-gwasexacthw


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add the R library `gstat` (`r-gstat`) to the list of migrations to be built on Arm64