### PR TITLE
add jags and r-rjags to osx_arm64.txt to add arm64 support.

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -530,6 +530,7 @@ isl
 islpy
 iteration_utilities
 itk
+jags
 jama
 jbig
 jemalloc
@@ -1241,6 +1242,7 @@ r-reticulate
 r-rfast
 r-rhpcblasctl
 r-rhub
+r-rjags
 r-rmpfr
 r-rngwell
 r-robustbase


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is my first time adding packages to be migrated to arm64 support. jags should be a very safe port to arm64 because it's already been packaged by homebrew there for a while: https://formulae.brew.sh/formula/jags

My group would really like if r-rjags were available for Apple Silicon.


