### PR TITLE
fix thrift migration situation

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -859,7 +859,7 @@ tbb_devel:
 tensorflow:
   - "2.16"
 thrift_cpp:
-  - 0.18.1
+  - 0.19.0
 tinyxml2:
   - '10'
 tk:

--- a/recipe/migrations/libthrift0200.yaml
+++ b/recipe/migrations/libthrift0200.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind: version
   migration_number: 1
 thrift_cpp:
-- 0.19.0
+- 0.20.0
 libthrift:
-- 0.19.0
-migrator_ts: 1693762377.7427814
+- 0.20.0
+migrator_ts: 1723520126.3329713


### PR DESCRIPTION
Thrift 0.19 has long run its course (only one dead [feedstock](https://github.com/conda-forge/heavydb-ext-feedstock/pull/57) left), and actually, there was already another thrift migration for 0.20, which however only tackled one of two pins (https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/6dd6978d6c56b71805ba46a86ee8637872223bd4). Close 0.19 and re-migrate 0.20