### PR TITLE
shut down pypy migrators (but don't delete yet)

### DIFF
--- a/recipe/migrations/pypy38.yaml
+++ b/recipe/migrations/pypy38.yaml
@@ -16,7 +16,7 @@ __migrator:
       - 3.7.* *_73_pypy
       - 3.8.* *_73_pypy
       - 3.9.* *_73_pypy
-  paused: False
+  paused: True
   longterm: True
   use_local: False
   check_solvable: True


### PR DESCRIPTION
As discussed/announced in https://github.com/conda-forge/conda-forge.github.io/pull/2259