### PR TITLE
migrate for libboost 1.86

### DIFF
--- a/recipe/migrations/libboost186.yaml
+++ b/recipe/migrations/libboost186.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for libboost 1.86"
+  migration_number: 1
+libboost_devel:
+- "1.86"
+libboost_python_devel:
+- "1.86"
+migrator_ts: 1723764795.6693385


### PR DESCRIPTION
The last two boost migrations had a whole lot going on (1.82: output reshuffling, 1.84: guinea pig for stdlib), this one should be calmer. @conda-forge/boost @conda-forge/core

PS. AFAIU the bot generating the migration PRs has some logic that depends on the feedstock name somehow, which is why I did this manually.