### PR TITLE
DISCUSS: pause boost migration

### DIFF
--- a/recipe/migrations/libboost186.yaml
+++ b/recipe/migrations/libboost186.yaml
@@ -3,6 +3,7 @@ __migrator:
   kind: version
   commit_message: "Rebuild for libboost 1.86"
   migration_number: 1
+  paused: true
 libboost_devel:
 - "1.86"
 libboost_python_devel:


### PR DESCRIPTION
Hey @conda-forge/boost @conda-forge/core 

I'm seeing way more breakage (from the first couple of PRs) for boost 1.86 than we've seen for 1.84 and 1.82. That impression may be subjective, but in particular it seems that there were a bunch of deprecations [executed](https://www.boost.org/doc/libs/1_86_0/libs/filesystem/doc/release_history.html) in `boost::filesystem` since 1.84 (removed members and even headers) that several projects seem to be running into -- so far 12 out of the feedstocks for which we [have PRs](https://github.com/pulls?q=is%3Apr+org%3Aconda-forge+archived%3Afalse+%22Rebuild+for+libboost+1.86%22+is%3Aopen):

* https://github.com/conda-forge/casacore-feedstock/pull/92
* https://github.com/conda-forge/collada-dom-feedstock/pull/12
* https://github.com/conda-forge/dakota-feedstock/pull/50
* https://github.com/conda-forge/fenics-feedstock/pull/215
* https://github.com/conda-forge/hpp-util-feedstock/pull/18
* https://github.com/conda-forge/hugin-feedstock/pull/63
* https://github.com/conda-forge/ledger-feedstock/pull/39
* https://github.com/conda-forge/mongodb-feedstock/pull/95
* https://github.com/conda-forge/qvina-feedstock/pull/8
* https://github.com/conda-forge/scine-utilsos-feedstock/pull/16
* https://github.com/conda-forge/standardese-feedstock/pull/12
* https://github.com/conda-forge/vina-feedstock/pull/18

AFAIU, to a degree the higher cadence for boost was predicated on these migrations running pretty smoothly. Since boost 1.86 is very fresh, we may want to give the ecosystem some time to adapt before we try this. The alternative is that the migration runs more slowly, and/or that we need to patch some things in affected feedstocks.

We can also delete the migrator instead of pausing, this PR is just to discuss that topic. I'm fine with letting it run, pausing it, or deleting it and retrying in a few months.