### PR TITLE
Correct aws-c-common pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -227,7 +227,7 @@ aws_c_auth:
 aws_c_cal:
   - 0.7.3
 aws_c_common:
-  - 0.9.26
+  - 0.9.27
 aws_c_compression:
   - 0.2.18
 # coupled to aws_c_common version bump, see


### PR DESCRIPTION
The migrators closes were merged in reverse order leading to a wrong pin.