### PR TITLE
feat: add hint for python-build as opposed to build

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -4,6 +4,11 @@ matplotlib = """\
     Recipes should usually depend on `matplotlib-base` as opposed to \
     `matplotlib` so that runtime environments do not require large \
     packages like `qt`."""
+build = """\
+    Recipes should depend on `python-build` as opposed to \
+    `build`. The `conda-forge` name for `https://github.com/pypa/build` is \
+    `python-build` in order to eliminate ambiguity. The `build` feedstock is \
+    archived and unmaintained."""
 jpeg = """\
     Recipes should usually depend on `libjpeg-turbo` as opposed to \
     `jpeg` for improved performance. For more information please see \


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adds a hint for python-build as opposed to build.