### PR TITLE
couple libboost 1.86 with assimp 5.4.2

### DIFF
--- a/recipe/migrations/libboost186.yaml
+++ b/recipe/migrations/libboost186.yaml
@@ -3,6 +3,8 @@ __migrator:
   kind: version
   commit_message: "Rebuild for libboost 1.86"
   migration_number: 1
+assimp:
+- 5.4.2
 libboost_devel:
 - "1.86"
 libboost_python_devel:


### PR DESCRIPTION
Unfortunately I hadn't seen #6116 at the time of #6296, and of course they're now logjammed because only assimp 5.4.2 has been rebuilt for boost 1.86.

Closes #6116