### PR TITLE
End poppler 24.08 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -184,8 +184,6 @@ pin_run_as_build:
     max_pin: x
   netcdf-cxx4:
     max_pin: x.x
-  poppler:
-    max_pin: x.x
   vlfeat:
     max_pin: x.x.x
 
@@ -746,7 +744,7 @@ pixman:
 poco:
   - 1.13.3
 poppler:
-  - '24.07'
+  - '24.08'
 postgresql:
   - '16'
 postgresql_plpython:

--- a/recipe/migrations/poppler2408.yaml
+++ b/recipe/migrations/poppler2408.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for poppler 24.08
-  kind: version
-  migration_number: 1
-migrator_ts: 1723090427.2480128
-poppler:
-- '24.08'


### PR DESCRIPTION
All except the stale KDE feedstocks have been migrated.