### PR TITLE
Pause Pytorch 2.4 since it was built without numpy for osx

### DIFF
--- a/recipe/migrations/pytorch24.yaml
+++ b/recipe/migrations/pytorch24.yaml
@@ -3,6 +3,7 @@ __migrator:
   commit_message: Rebuild for pytorch 2.4
   kind: version
   migration_number: 1
+  paused: True
 libtorch:
 - '2.4'
 migrator_ts: 1724386221.5909793


### PR DESCRIPTION
xref: https://github.com/conda-forge/torchani-feedstock/pull/39

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
