### PR TITLE
Also add pinning for libboost_headers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -449,6 +449,8 @@ libblitz:
   - 1.0.2
 libboost_devel:
   - '1.84'
+libboost_headers:
+  - '1.84'
 libboost_python_devel:
   - '1.84'
 libcint:

--- a/recipe/migration_support/packages_to_migrate_together.yaml
+++ b/recipe/migration_support/packages_to_migrate_together.yaml
@@ -3,6 +3,7 @@
 
 libboost_devel:
   - libboost_devel
+  - libboost_headers
   - libboost_python_devel
 
 gdal:

--- a/recipe/migrations/libboost186.yaml
+++ b/recipe/migrations/libboost186.yaml
@@ -7,6 +7,8 @@ assimp:
 - 5.4.2
 libboost_devel:
 - "1.86"
+libboost_headers:
+- "1.86"
 libboost_python_devel:
 - "1.86"
 migrator_ts: 1723764795.6693385


### PR DESCRIPTION
The current status of vtk only depends on this and I feel like the version is getting vendored somewhere

https://github.com/conda-forge/vtk-feedstock/blob/2c370467f4199dde94278ebf6152db72e99084c2/recipe/meta.yaml#L102

See how petpvc finds a vendoered version of boost
https://github.com/conda-forge/petpvc-feedstock/pull/11

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
