### PR TITLE
Add global pins for LALSuite

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -542,6 +542,20 @@ libiio:
   - 0
 libitk_devel:
   - 5.4
+liblal:
+  - 7
+liblalburst:
+  - 2
+liblalframe:
+  - 3
+liblalinference:
+  - 4
+liblalinspiral:
+  - 5
+liblalmetaio:
+  - 4
+liblalpulsar:
+  - 6
 liblalsimulation:
   - 5
 libmed:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -542,6 +542,8 @@ libiio:
   - 0
 libitk_devel:
   - 5.4
+liblalsimulation:
+  - 5
 libmed:
   - '4.1'
 libmatio:


### PR DESCRIPTION
This PR adds global pins for the libraries that form LALSuite, the most widely used set of C libraries in gravitational wave astrophysics.

Most of these don't change often, so hopefully this won't present a new regular migration burden for the conda-forge infrastructure.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
