### PR TITLE
exclude scipy from 3.13 migrator

### DIFF
--- a/recipe/migrations/python313.yaml
+++ b/recipe/migrations/python313.yaml
@@ -29,6 +29,8 @@ __migrator:
         - pypy-meta
         - cross-python
         - python_abi
+        # see https://github.com/conda-forge/scipy-feedstock/pull/283
+        - scipy
     exclude_pinned_pkgs: false
     additional_zip_keys:
         - channel_sources


### PR DESCRIPTION
The bot will keep falling over the lack of minor version, because it'll retry to overwrite the feedstock-local `python313.yaml` file and _then_ rerender. Simply remove it from the migration will allow things to proceed. PR has been done manually: https://github.com/conda-forge/scipy-feedstock/pull/283