### PR TITLE
migrations/osx_arm64.txt: add fluidfft and fluidsim

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -346,6 +346,8 @@ fitsio
 flake8-annotations
 flash
 flatbuffers
+fluidfft
+fluidsim
 fonttools
 forcebalance
 forestci


### PR DESCRIPTION
I would like to have fluidsim and fluidfft added to the migrations/osx_arm64.txt. Is it correct that I need to propose this as a PR?
