### PR TITLE
Close vtk 9.3.0 migration and vtk 9.3.1 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -899,7 +899,9 @@ vlfeat:
 volk:
   - '3.1'
 vtk:
-  - 9.2.6
+  - 9.3.0
+vtk_base:
+  - 9.3.0
 wcslib:
   - '8'
 wxwidgets:

--- a/recipe/migration_support/packages_to_migrate_together.yaml
+++ b/recipe/migration_support/packages_to_migrate_together.yaml
@@ -71,3 +71,7 @@ sqlite:
 pytorch:
   - libtorch
   - pytorch
+
+vtk:
+  - vtk_base
+  - vtk

--- a/recipe/migrations/vtk930.yaml
+++ b/recipe/migrations/vtk930.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1718606940.144743
-vtk:
-- 9.3.0

--- a/recipe/vtk931.yaml
+++ b/recipe/vtk931.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.3.1"
+  migration_number: 1
+migrator_ts: 1726738929.969102
+vtk_base:
+- 9.3.1
+vtk:
+- 9.3.1


### PR DESCRIPTION
Close vtk 9.3.0 migration as most open PRs are for feedstocks that have many unmerged migration PRs, and vtk 9.3.0 is missing several migrations (libboost 1.86 and proj 9.5 in particular, so it should fix https://github.com/conda-forge/vtk-feedstock/issues/346).

Furthermore, I also added `vtk-base` to the migration, to fix https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/6306 .


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
