### PR TITLE
Move recipe/vtk931.yaml file in recipe/migrations/vtk931.yaml

### DIFF
--- a/recipe/migrations/vtk931.yaml
+++ b/recipe/migrations/vtk931.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.3.1"
+  migration_number: 1
+migrator_ts: 1726738929.969102
+vtk_base:
+- 9.3.1
+vtk:
+- 9.3.1


### PR DESCRIPTION
Leftover from https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6435, in there I added the `vtk931.yaml` file in the wrong directory.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
