### PR TITLE
Close out migration for imath 3.1.12

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -414,7 +414,7 @@ icu:
 idyntree:
   - '13'
 imath:
-  - 3.1.11
+  - 3.1.12
 ipopt:
   - 3.14.16
 isl:

--- a/recipe/migrations/imath3112.yaml
+++ b/recipe/migrations/imath3112.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for imath 3.1.12
-  kind: version
-  migration_number: 1
-imath:
-- 3.1.12
-migrator_ts: 1725984290.0027597


### PR DESCRIPTION
only https://github.com/conda-forge/openimageio-feedstock/pull/110 is left which the feedstock seems a little abandonned

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
