### PR TITLE
add new abseil/grpc/protobuf migration

### DIFF
--- a/recipe/migrations/libabseil20240722_grpc165_libprotobuf5275.yaml
+++ b/recipe/migrations/libabseil20240722_grpc165_libprotobuf5275.yaml
@@ -1,0 +1,18 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20240722, libgrp 1.65 & libprotobuf 5.27.5
+  kind: version
+  paused: true
+  migration_number: 1
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    - protobuf
+libabseil:
+- 20240722
+libgrpc:
+- "1.65"
+libprotobuf:
+- 5.27.5
+migrator_ts: 1727040240.8650293


### PR DESCRIPTION
This has been a long time coming, but we managed to unblock the protobuf situation now after upstream forced a build backend change to bazel (which itself depends on protobuf in our builds).

I'm adding the migration as paused for now to build out the baseline packages.

See also #4075, and the sketched [plan](https://github.com/conda-forge/protobuf-feedstock/pull/215#issuecomment-2360810110). There's already grpc 1.66 & libprotobuf 5.28.2, but given that this is all very fresh, I'd prefer to do smaller version jumps, and fix things as we go. Once we've got this migration out of the way, we can jump to the newest builds.

CC @conda-forge/abseil-cpp @conda-forge/grpc-cpp @conda-forge/libprotobuf @conda-forge/protobuf