### PR TITLE
Update pins for Azure Storage September 2024 release

### DIFF
--- a/recipe/migrations/azure_storage_202409.yaml
+++ b/recipe/migrations/azure_storage_202409.yaml
@@ -1,0 +1,19 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for Azure Storage September release
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+azure_storage_common_cpp:
+- 12.8.0
+azure-storage-blobs:
+- 12.13.0
+azure-storage-files-datalake:
+- 12.12.0
+azure-storage-files-shares:
+- 12.11.0
+azure-storage-queues:
+- 12.4.0
+azure_identity_cpp:
+- 1.9.0
+migrator_ts: 1727284744.505542


### PR DESCRIPTION
Closes #6253
Closes #6469

cc: @teo-tsirpanis @h-vetinari @jjerphan @conda-forge/azure-storage-common-cpp

To minimize the number of migrations, in this PR I have combined the latest azure-identity-cpp migration (#6253) along with the latest azure-storage-*-cpp versions from the Azure Storage September Release (https://github.com/Azure/azure-sdk-for-cpp/pull/5967).

xref:
  * Previous discussions of this plan: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6208
  * Previous implementation of this plan: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6210
  * Related feedstock PRs: https://github.com/conda-forge/azure-storage-common-cpp-feedstock/pull/19, https://github.com/conda-forge/azure-storage-blobs-cpp-feedstock/pull/16, https://github.com/conda-forge/azure-storage-files-datalake-cpp-feedstock/pull/17, https://github.com/conda-forge/azure-storage-queues-cpp-feedstock/pull/10