### PR TITLE
azure_storage_202409: Use underscores for package names in migrator file

### DIFF
--- a/recipe/migrations/azure_storage_202409.yaml
+++ b/recipe/migrations/azure_storage_202409.yaml
@@ -6,13 +6,13 @@ __migrator:
   exclude_pinned_pkgs: false
 azure_storage_common_cpp:
 - 12.8.0
-azure-storage-blobs:
+azure_storage_blobs:
 - 12.13.0
-azure-storage-files-datalake:
+azure_storage_files_datalake:
 - 12.12.0
-azure-storage-files-shares:
+azure_storage_files_shares:
 - 12.11.0
-azure-storage-queues:
+azure_storage_queues:
 - 12.4.0
 azure_identity_cpp:
 - 1.9.0


### PR DESCRIPTION
Quick follow-up to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6471

I accidentally used dashes instead of underscores in the package names, which broke the bot

https://conda-forge.org/status/migration/?name=azure_storage_202409
https://github.com/regro/cf-scripts/actions/runs/11051541056

cc: @xhochy @conda-forge/azure-storage-common-cpp