### PR TITLE
Fix azure storage package names for September release migration

### DIFF
--- a/recipe/migrations/azure_storage_202409.yaml
+++ b/recipe/migrations/azure_storage_202409.yaml
@@ -6,13 +6,13 @@ __migrator:
   exclude_pinned_pkgs: false
 azure_storage_common_cpp:
 - 12.8.0
-azure_storage_blobs:
+azure_storage_blobs_cpp:
 - 12.13.0
-azure_storage_files_datalake:
+azure_storage_files_datalake_cpp:
 - 12.12.0
-azure_storage_files_shares:
+azure_storage_files_shares_cpp:
 - 12.11.0
-azure_storage_queues:
+azure_storage_queues_cpp:
 - 12.4.0
 azure_identity_cpp:
 - 1.9.0


### PR DESCRIPTION
3rd attempt to get this combined migration right. I forgot the `_cpp` in the package names.

https://conda-forge.org/status/migration/?name=azure_storage_202409

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6471, https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6473, https://github.com/conda-forge/tiledb-feedstock/pull/356/files#r1779084077