### PR TITLE
add migration groups for mumps, petsc

### DIFF
--- a/recipe/migration_support/packages_to_migrate_together.yaml
+++ b/recipe/migration_support/packages_to_migrate_together.yaml
@@ -28,6 +28,16 @@ mkl:
   - mkl
   - mkl_devel
 
+mumps:
+  - mumps-mpi
+  - mumps-seq
+
+petsc:
+  - petsc
+  - petsc4py
+  - slepc
+  - slepc4py
+
 libscotch:
   - libscotch
   - libptscotch


### PR DESCRIPTION
closes #540 

If we closed #6486 and #6483 would the bot make a new PR migrating both? Or will this not have an effect until the next version bump?