### PR TITLE
Add ace to conda-forge global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -219,6 +219,8 @@ blas_impl:
 # this output was dropped as of libabseil 20230125
 abseil_cpp:
   - '20220623.0'
+ace:
+  - '8.0.1'
 alsa_lib:
   - '1.2'
 antic:


### PR DESCRIPTION
`ace` is a package that has a `run_exports`, see https://github.com/conda-forge/ace-feedstock/blob/58820c45873a9bfd22407e75888b3c0243bde926/recipe/meta.yaml#L17 . 

Until now, the only package that used it in conda-forge was `yarp`, so abi migration were not particularly useful. However, I recently added another package that depends on `ace` in https://github.com/conda-forge/staged-recipes/pull/27692 , I obviously immediately had problems has the ace version used by both was different. I know rebuilt both packages to use `ace` 8.0.1, and at this point I think it would be convenient to have `ace` in the global pinnings. `ace` does not have frequent releases, and the migration would only impact two packages that are actively tested against conda-forge dependencies in their upstream CI, so I would expect that the ace migration should be fast.



Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
