### PR TITLE
Add fluidfft-fftw and fluidimage to migrations/osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -349,6 +349,8 @@ flake8-annotations
 flash
 flatbuffers
 fluidfft
+fluidfft-fftw
+fluidimage
 fluidsim
 fonttools
 forcebalance


### PR DESCRIPTION
I'd like to have these two packages built for osx_arm64...