### PR TITLE
Combine migrations for azure-core-cpp 1.14.0 and azure-identity-cpp 1.10.0

### DIFF
--- a/recipe/migrations/azure_core_cpp1140.yaml
+++ b/recipe/migrations/azure_core_cpp1140.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure_core_cpp 1.14.0 and azure_identity_cpp 1.10.0
+  kind: version
+  migration_number: 1
+azure_core_cpp:
+- 1.14.0
+azure_identity_cpp:
+- 1.10.0
+migrator_ts: 1728066241.096861


### PR DESCRIPTION
In order to reduce migration churn, this PR combines the azure-core-cpp 1.14.0 migration (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6503) with the azure-identity-cpp 1.10.0 migration (soon to be released in https://github.com/conda-forge/azure-identity-cpp-feedstock/pull/14).

I don't think I need `exclude_pinned_pkgs: false` for this PR. [azure-core-cpp-feedstock](https://github.com/conda-forge/azure-core-cpp-feedstock) doesn't have any azure pins in `.ci_support/`, and [azure-identity-cpp-feedstock](https://github.com/conda-forge/azure-identity-cpp-feedstock) only has azure_core_cpp, which I already manually migrated in https://github.com/conda-forge/azure-identity-cpp-feedstock/pull/14/commits/025f375749fd4bdda71ce3b830b0667e05f359f3.

cc: @conda-forge/azure-core-cpp, @conda-forge/azure-identity-cpp