### PR TITLE
Drop Docker image for `linux-armv7l`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -136,7 +136,6 @@ docker_image:                                   # [os.environ.get("BUILD_PLATFOR
   - quay.io/condaforge/linux-anvil-cos7-x86_64  # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
   - quay.io/condaforge/linux-anvil-aarch64      # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
   - quay.io/condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
-  - quay.io/condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
 
   # CUDA 11.8
   - quay.io/condaforge/linux-anvil-cuda:11.8              # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]


### PR DESCRIPTION
AFAIK ARM support has been pretty focused on ARM 8+. We essentially skipped over ARM 7 (modulo some bits like this one)

We did produce Docker images for ARM 7 previously. However those were dropped in mid-2020 with PR ( https://github.com/conda-forge/docker-images/pull/145 ). We have not built them since

In the org there are [a few references to ARM 7]( https://github.com/search?q=org%3Aconda-forge+linux-armv7l&type=code&p=1 ), which appear to be one of the following:

* Meeting notes
* Release notes
* Repodata logic (which handles all OSes & archs)
* CUDA 12 migrators (which need to specify everything for ordering purposes even when unused)

So AFAICT ARM 7 is not used anywhere. Think we can safely drop this line. Though please let me know if I'm missing something

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
