### PR TITLE
Undo re2 bump for now

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -814,7 +814,7 @@ qtkeychain:
 rdma_core:
   - '53'
 re2:
-  - 2024.07.02
+  - 2023.09.01
 readline:
   - "8"
 rocksdb:


### PR DESCRIPTION
We need to undo 22886ad33d3c8031eeecf56261898bd2ddb01443 until we've fixed https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/879 / https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/issues/880, because this is creating problems in re2-related packages, particularly arrow (migrations are stuck already)

I've added the a [backport](https://github.com/conda-forge/re2-feedstock/pull/85) of the removal of the upper bound for 2023.09.01, so at least packages being produced from yesterday onwards should not have this problem