### PR TITLE
Delete outdated aws_c_http089

### DIFF
--- a/recipe/migrations/aws_c_http089.yaml
+++ b/recipe/migrations/aws_c_http089.yaml
@@ -1,9 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for aws_c_http 0.8.9
-  kind: version
-  migration_number: 1
-  automerge: true
-aws_c_http:
-- 0.8.9
-migrator_ts: 1726030721.2608519


### PR DESCRIPTION
aws_c_http 0.8.10 has already been migrated.