### PR TITLE
Close out openexr 3.3 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -710,7 +710,7 @@ occt:
 openblas:
   - 0.3.*
 openexr:
-  - '3.2'
+  - '3.3'
 openh264:
   - 2.4.1
 openjpeg:

--- a/recipe/migrations/openexr33.yaml
+++ b/recipe/migrations/openexr33.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for openexr 3.3
-  kind: version
-  migration_number: 1
-migrator_ts: 1728937031.4820445
-openexr:
-- '3.3'


### PR DESCRIPTION
I feel like the bot really got caught in an unfortunate circumstance.

Feedstocks have been migrated, usual stragglers left behind

cc: @conda-forge/openexr 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
