### PR TITLE
Add migration for libgrpc 1.67 and libprotobuf 5.28.2

### DIFF
--- a/recipe/migrations/libgrpc167_libprotobuf5282.yaml
+++ b/recipe/migrations/libgrpc167_libprotobuf5282.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libgrpc 1.67 & libprotobuf 5.28.2
+  kind: version
+  migration_number: 1
+libgrpc:
+- "1.67"
+libprotobuf:
+- 5.28.2
+migrator_ts: 1729238463


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
