### PR TITLE
MNT: Add migration for root_base v6.32.2

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -73,8 +73,8 @@ else
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir "${RECIPE_ROOT}" -m "${CONFIG_FILE}" || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/recipe/migrations/root_base6322.yaml
+++ b/recipe/migrations/root_base6322.yaml
@@ -1,0 +1,7 @@
+migrator_ts: 1729238352
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+root_base:
+  - 6.32.2


### PR DESCRIPTION
The current root_base global pin of `6.32.0` is incompatible with `gxx_linux-64 13.*`. Using PR https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5229 as a reference for this PR.

```
Could not solve for environment specs
The following packages are incompatible
├─ gxx_linux-64 13.*  is requested and can be installed;
└─ root_base >=6.32.0,<6.32.1.0a0  is not installable because it requires
   └─ gxx_linux-64 12.* , which conflicts with any installable versions previously reported.
```

* Required for https://github.com/conda-forge/staged-recipes/pull/27903


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [N/A] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
