### PR TITLE
Add s5cmd to arch rebuild list

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -977,6 +977,7 @@ rosdep
 rosdistro
 rrdtool
 ruff
+s5cmd
 sage
 sasktran2
 scalene
@@ -1036,7 +1037,6 @@ sunpy
 supervisor
 sympy
 systemd
-s5cmd
 tango-access-control
 tango-admin
 tango-database

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -1036,6 +1036,7 @@ sunpy
 supervisor
 sympy
 systemd
+s5cmd
 tango-access-control
 tango-admin
 tango-database


### PR DESCRIPTION
Enable Linux aarch64 builds for s5cmd

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
