### PR TITLE
Revert "Undo re2 bump for now"

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -815,7 +815,7 @@ qtkeychain:
 rdma_core:
   - '53'
 re2:
-  - 2023.09.01
+  - 2024.07.02
 readline:
   - "8"
 rocksdb:


### PR DESCRIPTION
This reverts commit cc9f63adea7ebf8614755932e9f54acce9f70d12 (#6536) and thus reapplies 22886ad33d3c8031eeecf56261898bd2ddb01443 (#6516). This shouldn't be an issue anymore after https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/879.