### PR TITLE
Add hint to drop `pathlib`

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -4,6 +4,12 @@ matplotlib = """\
     Recipes should usually depend on `matplotlib-base` as opposed to \
     `matplotlib` so that runtime environments do not require large \
     packages like `qt`."""
+pathlib = """\
+    As of Python 3.4+, `pathlib` is part of the standard library. \
+    Recipes should drop the `pathlib` dependency as it is sunset.
+    
+    xref: https://peps.python.org/pep-0428/
+    xref: https://github.com/conda-forge/admin-requests/pull/1113"""
 build = """\
     Recipes should depend on `python-build` as opposed to \
     `build`. The `conda-forge` name for `https://github.com/pypa/build` is \


### PR DESCRIPTION
This adds a hint to recipes to drop `pathlib`. It is part of the standard library of Python 3.4+

The backport has long since been unmaintained and was recently archived. It will not be packaged for Python 3.13

xref: https://peps.python.org/pep-0428/
xref: https://github.com/conda-forge/admin-requests/pull/1113
xref: https://github.com/conda-forge/pathlib-feedstock/pull/21

cc @ocefpaf

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
