### PR TITLE
Revert pinning of "pyqt". They already mismatch in terms of minor version to qt-main

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -795,11 +795,11 @@ is_freethreading:
 pytorch:
   - '2.4'
 pyqt:
-  - 5.15.8
+  - 5.15
 pyqtwebengine:
-  - 5.15.8
+  - 5.15
 pyqtchart:
-  - 5.15.8
+  - 5.15
 qhull:
   - 2020.2
 qpdf:


### PR DESCRIPTION
Sorry I merged this in in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5670 and it was brought to my attention in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5670#issuecomment-2442791526 that this is not correct.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
