### PR TITLE
Add migrator for portaudio 19.7

### DIFF
--- a/recipe/migrations/portaudio197.yaml
+++ b/recipe/migrations/portaudio197.yaml
@@ -3,6 +3,6 @@ __migrator:
   commit_message: Rebuild for portaudio 19.7
   kind: version
   migration_number: 1
-libmatio:
+portaudio:
 - 19.7
 migrator_ts: 1730375181.934707

--- a/recipe/migrations/portaudio197.yaml
+++ b/recipe/migrations/portaudio197.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for portaudio 19.7
+  kind: version
+  migration_number: 1
+libmatio:
+- 19.7
+migrator_ts: 1730375181.934707


### PR DESCRIPTION
We do not have any pin for portaudio, even if it is a package that contains a shared library with a run_exports (see https://github.com/conda-forge/portaudio-feedstock/blob/f44a5cdbd074197009f575b2c73b575ba558c90e/recipe/meta.yaml#L17) and it is a dependency of several packages across conda-forge (https://github.com/search?q=org%3Aconda-forge+portaudio+language%3AYAML&type=code).

As done for example in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3931, first I add a migrator for portaudio 19.7 to ensure that all feedstocks use the latest portaudio, and then I intend to add a pin for portaudio once the migrator is done.

Fix https://github.com/conda-forge/portaudio-feedstock/issues/23 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
