### PR TITLE
Revert #5670 qt5 pinning while 5.15.15 was built

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -805,12 +805,9 @@ qhull:
 qpdf:
   - 11
 qt:
-  - 5.15.8
-# qt-main is temporarily (as of Oct 25, 2024) pinned to 5.15.8 to help with the
-# build out of the qt stack for 5.15.15
-# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5670
+  - 5.15
 qt_main:
-  - 5.15.8
+  - 5.15
 qt6_main:
   - '6.7'
 qtkeychain:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
