### PR TITLE
Add linter hint for obsolete `openmp` output

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -86,3 +86,4 @@ libgfortran-ng = """\
       ignore_run_exports_from:
         - {{ compiler("fortran") }}
     ```"""
+openmp = "The `openmp` output has been superseded by `llvm-openmp`."

--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -1,15 +1,5 @@
 [hints]
 # mapping from output-name-to-warn-on to hint-to-display
-matplotlib = """\
-    Recipes should usually depend on `matplotlib-base` as opposed to \
-    `matplotlib` so that runtime environments do not require large \
-    packages like `qt`."""
-pathlib = """\
-    As of Python 3.4+, `pathlib` is part of the standard library. \
-    Recipes should drop the `pathlib` dependency as it is sunset.
-    
-    xref: https://peps.python.org/pep-0428/
-    xref: https://github.com/conda-forge/admin-requests/pull/1113"""
 build = """\
     Recipes should depend on `python-build` as opposed to \
     `build`. The `conda-forge` name for `https://github.com/pypa/build` is \
@@ -29,6 +19,16 @@ libboost-python = """\
     is linking to libboost_python3x.so, use `libboost-python-devel` in the host \
     environment (which will create the correct dependence at runtime through a \
     run-export), or use `libboost-headers` if you only need the boost headers."""
+matplotlib = """\
+    Recipes should usually depend on `matplotlib-base` as opposed to \
+    `matplotlib` so that runtime environments do not require large \
+    packages like `qt`."""
+pathlib = """\
+    As of Python 3.4+, `pathlib` is part of the standard library. \
+    Recipes should drop the `pathlib` dependency as it is sunset.
+    
+    xref: https://peps.python.org/pep-0428/
+    xref: https://github.com/conda-forge/admin-requests/pull/1113"""
 pytorch-cpu = """\
     Please depend on `pytorch` directly, in order to avoid forcing \
     CUDA users to downgrade to the CPU version for no reason."""
@@ -46,6 +46,10 @@ boost-cpp = """\
 boost = """\
     The `boost` output has been superseded by `libboost-python-devel` (as of \
     1.82), which now comes with a run-export (on `libboost-python`) as well."""
+coincbc = """\
+    The `coincbc` package has been renamed to `coin-or-cbc`. It is now \
+    preferred to depend on the `coin-or-cbc` package in the host section and allow
+    the run_export define the runtime dependency."""
 grpc-cpp = "The `grpc-cpp` output has been superseded by `libgrpc`."
 importlib_metadata = "Use `importlib-metadata` instead of `importlib_metadata`"
 libgcc-ng = """\
@@ -60,12 +64,6 @@ libgcc-ng = """\
         - {{ compiler("c") }}    # depending on which...
         - {{ compiler("cxx") }}  # ... compilers you use
     ```"""
-coincbc = """\
-    The `coincbc` package has been renamed to `coin-or-cbc`. It is now \
-    preferred to depend on the `coin-or-cbc` package in th host section and allow
-    the run_export define the runtime dependency.
-"""
-
 libstdcxx-ng = """\
     `libstdcxx-ng` has been superseded by `libstdcxx`. Note however, that except in \
     truly exceptional cases, you should not have to add this manually; you can \


### PR DESCRIPTION
Just noticed to my great surprise that several feedstocks are still [using](https://github.com/search?q=org%3Aconda-forge+%2F-+openmp%5Cs%2F+path%3Arecipe%2Fmeta.yaml&type=code) `openmp` as a dependency, even though we haven't [built](https://anaconda.org/conda-forge/openmp/files) that for over 5 years. Let's alert them through the linter at least.