### PR TITLE
unpause nogil migration

### DIFF
--- a/recipe/migrations/python313t.yaml
+++ b/recipe/migrations/python313t.yaml
@@ -19,9 +19,8 @@ __migrator:
             - 3.7.* *_73_pypy
             - 3.8.* *_73_pypy
             - 3.9.* *_73_pypy
-    paused: true
     longterm: true
-    pr_limit: 20
+    pr_limit: 3
     max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
     exclude:
         # this shouldn't attempt to modify the python feedstocks


### PR DESCRIPTION
Now that we have a tagged cython [release](https://github.com/conda-forge/cython-feedstock/pull/149) that's compatible with nogil python (even if it's just an alpha...), I think it'd be OK to start the nogil migration. @isuruf has been doing this manually across a bunch of feedstocks already, but that doesn't show up in the status page anywhere.

Even if the migration will move only very slowly, I think it would be good to start it, if only for the increased visibility.