### PR TITLE
Provide a linter hint for xorg-proto packages

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -91,3 +91,7 @@ astropy = """\
     Recipes should usually depend on `astropy-base` as opposed to \
     `astropy`. `astropy-base` only has the required dependancies whereas \
     `astropy` now has all optional dependancies as well."""
+
+xorg_xextproto = """The use of `xorg-xextproto` is deprecated. \
+Please use `xorg-xorgproto` instead. It contains the latest version of the proto \
+packages and bundles them all together."""

--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -91,7 +91,9 @@ astropy = """\
     Recipes should usually depend on `astropy-base` as opposed to \
     `astropy`. `astropy-base` only has the required dependancies whereas \
     `astropy` now has all optional dependancies as well."""
-
-xorg_xextproto = """The use of `xorg-xextproto` is deprecated. \
-Please use `xorg-xorgproto` instead. It contains the latest version of the proto \
+xorg_xextproto = """The use of `xorg-xextproto` and `xorg-xproto` are deprecated. \
+Please use `xorg-xorgproto` instead. It contains the latest version of allthe proto \
+packages and bundles them all together."""
+xorg_xproto = """The use of `xorg-xextproto` and `xorg-xproto` are deprecated. \
+Please use `xorg-xorgproto` instead. It contains the latest version of all the proto \
 packages and bundles them all together."""


### PR DESCRIPTION
@pkgw I think this is not the ideal way, but we have been using the newer proto on some new recipes and I am noticing clobbering in a few environments. I think it would be fine to use this in lieu of a more complicated migration

Let me know what you think
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
