### PR TITLE
Add libgdal,gdal,libgdal_core 3.10 migration

### DIFF
--- a/recipe/migrations/libgdal310.yaml
+++ b/recipe/migrations/libgdal310.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+gdal:
+- '3.10'
+libgdal:
+- '3.10'
+libgdal_core:
+- '3.10'
+migrator_ts: 1731733901.4913723


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
*  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

With GDAL 3.9, a manual PR was needed #5883, so I assume the same with GDAL 3.10 with the bot not picking this up.

While I did raise some dependency concerns with this migration, conda-forge/gdal-feedstock#1004 , it likely is not going to make the situation any worse.