### PR TITLE
remove `BUILD:` override for aarch64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -187,13 +187,6 @@ zip_keys:
     - libarrow
     - libarrow_all
 
-
-# aarch64 specifics because conda-build sets many things to centos 6
-# this can probably be removed when conda-build gets updated defaults
-# for aarch64
-cdt_arch: aarch64                       # [aarch64]
-BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
-
 # armv7l specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults
 # for aarch64


### PR DESCRIPTION
Noticed this leftover today. Not touching armv7l because I don't think we have any alternatives available there.

CC @isuruf