### PR TITLE
Close nodejs22 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -698,8 +698,8 @@ netcdf_fortran:
 nettle:
   - '3.9'
 nodejs:
+  - '22'
   - '20'
-  - '18'
 nss:
   - 3
 nspr:

--- a/recipe/migrations/nodejs22.yaml
+++ b/recipe/migrations/nodejs22.yaml
@@ -1,9 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for nodejs 22
-  kind: version
-  migration_number: 1
-migrator_ts: 1720020160.6454718
-nodejs:
-- '22'
-- '20'


### PR DESCRIPTION
Most feedstocks have been migrated and the outstanding ones are either abandoned or ones I maintain that didn't get a release in a while.