### PR TITLE
Dual migration for HDF5 1.14.4 and 1.14.3

### DIFF
--- a/recipe/migrations/hdf51144.yaml
+++ b/recipe/migrations/hdf51144.yaml
@@ -1,8 +1,9 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for hdf5 1.14.4
+  commit_message: Rebuild for hdf5 1.14.4 (and keep 1.14.3)
   kind: version
-  migration_number: 1
+  migration_number: 2
 hdf5:
+- 1.14.3
 - 1.14.4
 migrator_ts: 1727986901.81392


### PR DESCRIPTION
See https://github.com/conda-forge/hdf5-feedstock/issues/240

Is this enough to retrigger the builds for the feedstocks that have already been migrated?
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
