### PR TITLE
Update CFEP 9 link in migration example

### DIFF
--- a/recipe/migrations/example.exyaml
+++ b/recipe/migrations/example.exyaml
@@ -1,5 +1,5 @@
 # To learn more about migrations read CFEP-09
-# https://github.com/conda-forge/conda-forge-enhancement-proposals/blob/master/cfep-09.md
+# https://github.com/conda-forge/cfep/blob/main/cfep-09.md
 # The timestamp of when the migration was made
 # Can be obtained by copying the output of
 # python -c "import time; print(f'{time.time():.0f}')"


### PR DESCRIPTION
The original link does redirect to the new location. However the repo was renamed and the branch was renamed (to replace `master` with `main`). So it is better to use the current URL for this CFEP.