### PR TITLE
Add dartsim-cpp to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -316,6 +316,8 @@ cutensor:
   - 2
 curl:
   - 8
+dartsim_cpp:
+  - '6.15'
 dav1d:
   - 1.2.1
 davix:


### PR DESCRIPTION
`dartsim-cpp` is a C++ package with a `run_exports`, on which several package on conda-forge depend.
I already checked that all these packages already have builds for dartsim==6.15.*, except for `gz-physics7` that I added in https://github.com/conda-forge/gz-physics-feedstock/pull/61 .

For this reason, I think it make sense to directly add the pinning of `dartsim-cpp` to 6.15, so that the rebuild for the next minor dartsim-cpp relase will be handed by ABI migration bots.

fyi @conda-forge/dartsim 


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
