### PR TITLE
Add librealsense to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -620,6 +620,8 @@ librbio:
   - '4'
 librdkafka:
   - '2.6'
+librealsense:
+  - '2.54'
 librsvg:
   - 2
 libsecret:


### PR DESCRIPTION
`librealsense` is a C++ package with a `run_exports`, and after https://github.com/conda-forge/staged-recipes/pull/28542 three packages depend on it, so I think it is time to add it to the pinning.


I already checked that all these packages already have builds for librealsense==2.54.*.

For this reason, I think it make sense to directly add the pinning of `librealsense` to 2.54, so that the rebuild for the next minor  `librealsense` relase will be handed by ABI migration bots.

fyi @conda-forge/librealsense

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
