### PR TITLE
Add r-bigrquery to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1232,6 +1232,7 @@ r-arrow
 r-bart
 r-base
 r-beeswarm
+r-bigrquery
 r-bipartite
 r-cairo
 r-catboost


### PR DESCRIPTION
Address https://github.com/conda-forge/r-bigrquery-feedstock/issues/26 following the instructions in https://conda-forge.org/docs/maintainer/knowledge_base/#apple-silicon-builds.