### PR TITLE
distinguish github_actions_labels for CPU vs. CUDA builds

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -173,10 +173,10 @@ docker_image:                                       # [os.environ.get("BUILD_PLA
   - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
 
 # to be overridden per feedstock; part of zip so that CPU builds can choose different agents than GPU builds
-github_actions_labels:          # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+github_actions_labels:                              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cirun-openstack-cpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cirun-openstack-gpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cirun-openstack-gpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 zip_keys:
   -                             # [unix]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -172,6 +172,12 @@ docker_image:                                       # [os.environ.get("BUILD_PLA
   - quay.io/condaforge/linux-anvil-aarch64:alma9    # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
   - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
 
+# to be overridden per feedstock; part of zip so that CPU builds can choose different agents than GPU builds
+github_actions_labels:          # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - dummy                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 zip_keys:
   -                             # [unix]
     - c_compiler_version        # [unix]
@@ -179,6 +185,7 @@ zip_keys:
     - fortran_compiler_version  # [unix]
     - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - github_actions_labels     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
   -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Some feedstocks have moved to the cirun open-gpu server, and even fewer are using GPU agents (basically tensorflow & pytorch). Those are the rarest resource (currently also at halved capacity due to some issues with the physical GPUs in the server).

Additionally, we cannot yet separate build and test phases into different agents, c.f. https://github.com/conda-forge/pytorch-cpu-feedstock/issues/314 & https://github.com/conda-forge/conda-smithy/issues/1472

As a consequence, a given pytorch PR currently takes at least >24h to complete, and that's if there are no competing GPU builds. To alleviate the pressure on the rarest resource, I'd like to zip `github_actions_labels` into the `cuda_compiler` zip, because this would allow us to at least choose CPU agents for the non-CUDA builds. An example based on this PR can be found on this [branch](https://github.com/h-vetinari/pytorch-cpu-feedstock/tree/cpu_vs_gpu).

This would very likely break the rendering of existing feedstocks on the open-gpu server, but there are [currently](https://github.com/search?q=org%3Aconda-forge+github_actions_labels+path%3Arecipe%2Fconda_build_config.yaml&type=code) only 7 of those, out of which only 5 are cuda-enabled (and it won't concern CPU-only feedstocks due to being gated on `CF_CUDA_ENABLED`), so IMO this should be manageable.

@conda-forge/pytorch-cpu 
@conda-forge/tensorflow 
@conda-forge/jaxlib
@conda-forge/libmagma
@conda-forge/flash-attn
