### PR TITLE
Reduce cuda complexity by dropping 11.8

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,6 @@ c_compiler:
 c_compiler_version:            # [unix]
   - 13                         # [linux]
   - 18                         # [osx]
-  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   # CUDA 12.4 on PPC does not support GCC 13
   - 12                         # [linux and ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 13                         # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
@@ -28,7 +27,6 @@ cxx_compiler:
 cxx_compiler_version:          # [unix]
   - 13                         # [linux]
   - 18                         # [osx]
-  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux and ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 13                         # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 llvm_openmp:                   # [osx]
@@ -41,7 +39,6 @@ fortran_compiler_version:      # [unix or win64]
   - 13                         # [linux]
   - 13                         # [osx]
   - 5                          # [win64]
-  - 11                         # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12                         # [linux and ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 13                         # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 m2w64_c_compiler:              # [win]
@@ -51,18 +48,13 @@ m2w64_cxx_compiler:            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
 
-cuda_compiler:
-  - None
-  - nvcc                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cuda-nvcc                  # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cuda_compiler_version:
   - None
-  - 11.8                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 12.4                       # [linux and ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 12.6                       # [((linux and not ppc64le) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12                         # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 cuda_compiler_version_min:
   - None                       # [osx]
-  - 11.8                       # [linux or win64]
+  - 12                         # [linux or win64]
 
 arm_variant_type:              # [aarch64]
   - sbsa                       # [aarch64]
@@ -147,16 +139,6 @@ docker_image:                                       # [os.environ.get("BUILD_PLA
   - quay.io/condaforge/linux-anvil-aarch64:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
   - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
 
-  # CUDA 11.8 builds (only x64 has a DEFAULT_LINUX_VERSION choice; alma9 not available)
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7     # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") == "cos7"]
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") in ("ubi8", "alma8", "alma9")]
-  # CUDA 11.8 arch: native compilation (build == target)
-  - quay.io/condaforge/linux-anvil-aarch64-cuda11.8:ubi8    # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
-  - quay.io/condaforge/linux-anvil-ppc64le-cuda11.8:ubi8    # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
-  # CUDA 11.8 arch: cross-compilation (build != target)
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-
   # CUDA 12 builds on CentOS 7
   - quay.io/condaforge/linux-anvil-x86_64:cos7      # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "cos7"]
   - quay.io/condaforge/linux-anvil-aarch64:cos7     # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "cos7"]
@@ -177,12 +159,8 @@ zip_keys:
     - c_compiler_version        # [unix]
     - cxx_compiler_version      # [unix]
     - fortran_compiler_version  # [unix]
-    - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
-  -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   -
     - python
     - numpy


### PR DESCRIPTION
For years we have struggled in maintainning the multiple cuda versions.

Personally, I feel that Nvidia has done tremendous work in ameliorating the situation here at Conda-forge.

However, I'm hoping to shed a little of bit of mental weight from cuda 11.8.

IMO the main projects that utilize it:
* pytorch - https://github.com/conda-forge/pytorch-cpu-feedstock/blob/main/recipe/meta.yaml#L58
* tensorflow - https://github.com/conda-forge/tensorflow-feedstock/blob/main/recipe/meta.yaml#L60
* jax - https://github.com/conda-forge/jaxlib-feedstock/blob/main/recipe/meta.yaml#L27
* onnxruntime https://github.com/conda-forge/onnxruntime-feedstock/blob/main/recipe/meta.yaml#L48

have all dropped CUDA 11.8 for lack of maintainer interest.

I think it is time for us to drop it from the global pinnings

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
