### PR TITLE
explicit wildcard on libblas version

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -210,13 +210,13 @@ pin_run_as_build:
 
 # blas
 libblas:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 libcblas:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 liblapack:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 liblapacke:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 blas_impl:
   - openblas
   - mkl          # [x86 or x86_64]


### PR DESCRIPTION
rattler-build 0.34 rejects `3.9 *netlib` as an ambiguous version spec, and requires explicit version range i.e. `3.9.* *netlib` for minor-version glob behavior, unlike conda-build. Both treat the explicit glob the same, I believe.

This ambiguity error appears to only be applied when the build string is also specified, so it's not that globs are required everywhere, just when the build string is pinned as well, which I believe is only on blas and friends.

This patch is required for any v1 recipe to depend on blas/lapack, I believe (failure seen in https://github.com/conda-forge/petsc-feedstock/pull/227).

origin: https://github.com/conda/rattler/pull/989 (I think) also discussed [on zulip](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/rattler-build.20.22strict.22.20matchspec.20parsing)