### PR TITLE
undo bump of aws-sdk-cpp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -270,7 +270,7 @@ aws_checksums:
 aws_crt_cpp:
   - 0.29.9
 aws_sdk_cpp:
-  - 1.11.488
+  - 1.11.458
 azure_core_cpp:
   - 1.14.0
 azure_identity_cpp:


### PR DESCRIPTION
Undo #6938 due to https://github.com/conda-forge/aws-sdk-cpp-feedstock/issues/924. Despite having originally merged the migration PRs (failures looked like flakes that we get occasionally), arrow has reverted all the bumps, and would not be buildable with the current global pinning. To give us some more time to figure out https://github.com/apache/arrow/issues/45304 with upstream, undo this bump; we can always redo it later.

CC @conda-forge/aws-sdk-cpp 