### PR TITLE
add initial migrator for obake and mppp

### DIFF
--- a/recipe/migrations/obake_mppp.yaml
+++ b/recipe/migrations/obake_mppp.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for obake 0.9 & mppp 2.0
+  kind: version
+  migration_number: 1
+obake:
+  - '0.9'
+mppp:
+  - '2.0'
+migrator_ts: 1737434112


### PR DESCRIPTION
Closes https://github.com/conda-forge/obake-feedstock/issues/38

We also need to handle the closely related mppp 1.x vs. 2.x anyway, so add that as well.

CC @conda-forge/obake @conda-forge/mppp @conda-forge/audi