### PR TITLE
Add aria-tools to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -37,6 +37,7 @@ apr
 apscheduler
 apsw
 arcjetcv
+aria-tools
 arm_pyart
 armadillo
 arosics


### PR DESCRIPTION
For reference, here is the conda-forge feedstock page for aria-tools: https://github.com/conda-forge/aria-tools-feedstock

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
