### PR TITLE
Revert "distinguish github_actions_labels for CPU vs. CUDA builds"

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -172,12 +172,6 @@ docker_image:                                       # [os.environ.get("BUILD_PLA
   - quay.io/condaforge/linux-anvil-aarch64:alma9    # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
   - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
 
-# to be overridden per feedstock; part of zip so that CPU builds can choose different agents than GPU builds
-github_actions_labels:                              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cirun-openstack-cpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cirun-openstack-gpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cirun-openstack-gpu-placeholder                 # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-
 zip_keys:
   -                             # [unix]
     - c_compiler_version        # [unix]
@@ -185,7 +179,6 @@ zip_keys:
     - fortran_compiler_version  # [unix]
     - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - github_actions_labels     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
   -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Reverts conda-forge/conda-forge-pinning-feedstock#6910