### PR TITLE
Add portaudio to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -809,6 +809,8 @@ poco:
   - 1.14.0
 poppler:
   - '24.12'
+portaudio:
+  - '19.7'
 postgresql:
   - '17'
 postgresql_plpython:


### PR DESCRIPTION
A [migrator was already done](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6633) to rebuild against the latest release (19.7), and I just noticed that this has not been added to the global pinnings after that migration completed. So this does that.

Ref:
  - https://github.com/conda-forge/portaudio-feedstock/issues/23
  - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6633

fyi @conda-forge/portaudio @traversaro

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~[ ] Bumped the build number (if the version is unchanged)~
* ~[ ] Reset the build number to `0` (if the version changed)~
* ~[ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~
* ~[ ] Ensured the license file is being packaged.~

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
