### PR TITLE
osx-arm64 migrate r-exactextractr

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1263,6 +1263,7 @@ r-distributionutils
 r-duckdb
 r-ecp
 r-essentials
+r-exactextractr
 r-fastmatch
 r-filelock
 r-fixest


### PR DESCRIPTION
Requested at https://github.com/conda-forge/r-exactextractr-feedstock/issues/36.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

