### PR TITLE
Add migration for proxsuite071

### DIFF
--- a/recipe/migrations/proxsuite071.yaml
+++ b/recipe/migrations/proxsuite071.yaml
@@ -5,5 +5,6 @@ __migrator:
   bump_number: 1
   commit_message: Rebuild for proxsuite 0.7.1
 
+# add to global pinning one compete
 proxsuite:
   - 0.7.1

--- a/recipe/migrations/proxsuite071.yaml
+++ b/recipe/migrations/proxsuite071.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1738924976
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: Rebuild for proxsuite 0.7.1
+
+proxsuite:
+  - 0.7.1


### PR DESCRIPTION
Tackles #6998
 
`proxsuite` should be added to global pinnings once migration complete.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

