### PR TITLE
Add wgrib2 to arch rebuil

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -1169,6 +1169,7 @@ vulkan-loader
 wabt
 watchfiles
 web3
+wgrib2
 wordcloud
 wurlitzer
 x265


### PR DESCRIPTION
I was sent here via https://github.com/conda-forge/wgrib2-feedstock/issues/42 and am testing out the CI arm build for wgrib2.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

