### PR TITLE
add migration for pytorch 2.6

### DIFF
--- a/recipe/migrations/pytorch26.yaml
+++ b/recipe/migrations/pytorch26.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pytorch 2.6
+  kind: version
+  migration_number: 1
+libtorch:
+- '2.6'
+pytorch:
+- '2.6'
+migrator_ts: 1739565601.4436605


### PR DESCRIPTION
After https://github.com/conda-forge/pytorch-cpu-feedstock/pull/326. As I [mentioned](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/326#issuecomment-2650298698) there, the plan is to roll out 2.6 across existing feedstocks first, and then do it again more slowly with a piggyback migrator that removes `skip: true  [win]` (though of course feedstock maintainers are encouraged to try that out individually as well).

It's possible we still have some bugs to iron out, in particular:
* https://github.com/conda-forge/pytorch-cpu-feedstock/issues/357
* https://github.com/conda-forge/pytorch-cpu-feedstock/issues/354 (which needs switching our MKL to llvm-openmp, which needs unblocking MKL 2025).

Please raise issues on the pytorch feedstock if something fishy is going on in one of the upgrade PRs.