### PR TITLE
raise an error when *.yml migration files are present

### DIFF
--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -7,6 +7,9 @@ migrations_path = Path(PREFIX) / 'share' / 'conda-forge' / 'migrations'
 
 print(f"Checking migrations in {migrations_path}")
 
+for filename in migrations_path.glob('*.yml'):
+    raise ValueError(f"Found {filename} with unexpected extension *.yml, please rename to *.yaml")
+
 for filename in migrations_path.glob('*.yaml'):
     print(f"Checking that we can read {filename}")
     with open(filename, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
As suggested in https://github.com/regro/cf-scripts/issues/3704, raise an error when we encounter any `*.yml` files.

Fixes https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/7029