### PR TITLE
set check_solvable: false for pytorch migration

### DIFF
--- a/recipe/migrations/pytorch26.yaml
+++ b/recipe/migrations/pytorch26.yaml
@@ -3,6 +3,8 @@ __migrator:
   commit_message: Rebuild for pytorch 2.6
   kind: version
   migration_number: 1
+  # see https://github.com/conda-forge/pytorch-cpu-feedstock/issues/362
+  check_solvable: false
 libtorch:
 - '2.6'
 pytorch:


### PR DESCRIPTION
Help the migration; for example a bunch of feedstocks aren't resolvable because of CUDA 11.8 having been dropped; see https://github.com/conda-forge/pytorch-cpu-feedstock/issues/362 & https://github.com/regro/cf-scripts/issues/3718

