### PR TITLE
Add xxhash to global pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -986,6 +986,8 @@ xerces_c:
   - 3.2
 xrootd:
   - '5'
+xxhash:
+  - 0.8.3
 xz:
   - 5
 zeromq:


### PR DESCRIPTION
After a rather long solver debugging session I found two packages build with inconsistent versions of xxhash so I propose to add it to the global pinning 😄 

cc @conda-forge/xxhash 