### PR TITLE
Add mesalib to global pinnings through migration

### DIFF
--- a/recipe/migrations/mesalib250.yaml
+++ b/recipe/migrations/mesalib250.yaml
@@ -1,0 +1,9 @@
+migrator_ts: 1740966467
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+# TODO: make sure to add this to the global pinnings
+mesalib:
+  - 25.0


### PR DESCRIPTION
I realize that I don't even have this in my environment anymore.....

Not sure why I ever needed it. 

Maybe it was for wxwidgets at the time
https://github.com/conda-forge/wxwidgets-feedstock/blob/main/recipe/meta.yaml#L62

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
