### PR TITLE
add new abseil/grpc/protobuf migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto.yaml
+++ b/recipe/migrations/absl_grpc_proto.yaml
@@ -1,0 +1,22 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20250127, libgrp 1.69 & libprotobuf 5.29.3
+  kind: version
+  migration_number: 1
+  paused: true
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    - protobuf
+    - re2
+libabseil:
+- 20250127
+libgrpc:
+- "1.69"
+libprotobuf:
+- 5.29.3
+# see https://github.com/grpc/grpc/commit/14ac94d923b80650e0df55bed17be5efa0e4becd
+c_stdlib_version:   # [osx and x86_64]
+  - 10.14           # [osx and x86_64]
+migrator_ts: 1741118046.5882597


### PR DESCRIPTION
Add a new migration, paused for now, while we prepare things (getting all interrelated versions ready, plus bazel).

I would have like to include [grpc 1.70](https://github.com/conda-forge/grpc-cpp-feedstock/pull/398), but they've had a massive regression in terms of how many symbols get put into `grpc.dll` (factor 8 more than before), and despite spending a lot of effort to split off something and get below that limit in for [1.68](https://github.com/conda-forge/grpc-cpp-feedstock/pull/384), they're right back over the limit again. 😑

This probably needs a bisect...

Closes #7082 
Closes #7083 
Closes #7089 
Closes #7097 
Closes #7101