### PR TITLE
start abseil/grpc/protobuf migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto.yaml
+++ b/recipe/migrations/absl_grpc_proto.yaml
@@ -1,6 +1,6 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for libabseil 20250127, libgrpc 1.70 & libprotobuf 5.29.3
+  commit_message: Rebuild for libabseil 20250127, libgrpc 1.71 & libprotobuf 5.29.3
   kind: version
   migration_number: 1
   exclude:
@@ -12,7 +12,7 @@ __migrator:
 libabseil:
 - 20250127
 libgrpc:
-- "1.70"
+- "1.71"
 libprotobuf:
 - 5.29.3
 # see https://github.com/grpc/grpc/commit/14ac94d923b80650e0df55bed17be5efa0e4becd

--- a/recipe/migrations/absl_grpc_proto.yaml
+++ b/recipe/migrations/absl_grpc_proto.yaml
@@ -1,9 +1,8 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for libabseil 20250127, libgrpc 1.69 & libprotobuf 5.29.3
+  commit_message: Rebuild for libabseil 20250127, libgrpc 1.70 & libprotobuf 5.29.3
   kind: version
   migration_number: 1
-  paused: true
   exclude:
     - abseil-cpp
     - grpc-cpp
@@ -13,7 +12,7 @@ __migrator:
 libabseil:
 - 20250127
 libgrpc:
-- "1.69"
+- "1.70"
 libprotobuf:
 - 5.29.3
 # see https://github.com/grpc/grpc/commit/14ac94d923b80650e0df55bed17be5efa0e4becd


### PR DESCRIPTION
Pending a green light from someone knowledgeable about grpc/protobuf, e.g. @xhochy or @mariusvniekerk.

More context [here](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075#issuecomment-2706073505).

Closes #7116
Closes #7139

CC @conda-forge/abseil-cpp @conda-forge/grpc-cpp @conda-forge/libprotobuf @conda-forge/protobuf

PS. I originally thought we'd have to abandon using gprc 1.70 due to the "too many symbols" issue, but that got resolved in the meantime, so bumping from 1.69 to ~1.70~ 1.71 here.