### PR TITLE
Add libcap 2.71 to global pinnings and migrate to 2.75

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -478,6 +478,8 @@ libbtf:
   - '2'
 libcamd:
   - '3'
+libcap:
+  - 2.71
 libcint:
   - '6.1'
 libccolamd:

--- a/recipe/migrations/libcap275.yaml
+++ b/recipe/migrations/libcap275.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1741547316
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libcap:
+  - 2.75


### PR DESCRIPTION
xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6804

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
