### PR TITLE
Change tinyxml2 pin from 10 to 10.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -951,7 +951,7 @@ tensorflow:
 thrift_cpp:
   - 0.21.0
 tinyxml2:
-  - '10'
+  - '10.0'
 tk:
   - 8.6                # [not ppc64le]
 tiledb:


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/tinyxml2-feedstock/issues/16, there was an (intentional) ABI break from tinyxml2 10.0 to 10.1 . So we can't pin just to `10` anymore, we need to pin to `10.0`. The idea after the merge of this PR is to start with a tinyxml2 10.1 migration.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
