### PR TITLE
add pysvg-py3 to linux-aarch64 with python <3.12

### DIFF
--- a/recipe/migrations/pysvg-py3022post3.yaml
+++ b/recipe/migrations/pysvg-py3022post3.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 0
+  commit_message: Rebuild for pysvg-py3 0.2.2.post3
+  kind: version
+  migration_number: 0
+migrator_ts: 1742300598
+pysvg-py3:
+- 0.2.2.post3


### PR DESCRIPTION
This PR is started to add new pins to pysvg-py3. The latest available version is 0.2.2.post3, and the maximum pin mode is x.x.x.

I only want to add libsass to linux-aarch64 with python 3.11.*.

@conda-forge-admin please ping qpdf