### PR TITLE
Drop geotiff 1.7.4 migration, loosen pin to 1.7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -381,7 +381,7 @@ libgdal_core:
 geos:
   - 3.13.0
 geotiff:
-  - 1.7.3
+  - '1.7'
 gfal2:
   - '2.23'
 gflags:

--- a/recipe/migrations/geotiff174.yaml
+++ b/recipe/migrations/geotiff174.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1742391067.6519449
-geotiff:
-- 1.7.4


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
*  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
*  Ensured the license file is being packaged.

The current run_exports on the geotiff repo are `x.x` , so I think we can remove the migration for 1.7.4 and just relax the pin specified here.  This is an alternative to #7194 