### PR TITLE
Add cms-combine to arch_rebuild.txt list

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -85,6 +85,7 @@ clhep
 clingo
 clpeak
 cmarkgfm
+cms-combine
 coinmp
 colima
 color-operations


### PR DESCRIPTION
* Add https://github.com/conda-forge/cms-combine-feedstock to the rebuild list for linux-aarch64 and linux-ppc64le.
   - Resolves https://github.com/conda-forge/cms-combine-feedstock/issues/10
   - Follow up to PR https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7072

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
