### PR TITLE
Start vtk and vtk_base 9.4.1 migration

### DIFF
--- a/recipe/migrations/vtk941.yaml
+++ b/recipe/migrations/vtk941.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.4.1"
+  migration_number: 1
+migrator_ts: 1742567043.969102
+vtk_base:
+- 9.4.1
+vtk:
+- 9.4.1


### PR DESCRIPTION
As happened in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6435, for some reason automatic migrations are not added automatically for vtk, so this PR adds the migration for vtk and vtk_base 9.4.1 after https://github.com/conda-forge/vtk-feedstock/pull/368 . This is important as migration are only ongoing for vtk 9.4.1 (see https://github.com/conda-forge/vtk-feedstock/pull/371) so we will soon reach an inconsistent migration state if we do not start the migration also for vtk 9.4.1 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
