### PR TITLE
Add nanoarrow to arch_rebuild.txt

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -474,6 +474,7 @@ mysql-connector-cpp
 mysql-connector-odbc
 n2p2
 nano
+nanoarrow
 nasm
 natcap.invest
 nb_conda_kernels


### PR DESCRIPTION
This adds `nanoarrow` to the `arch_rebuild.txt` list. We would like ARM support for nanoarrow usage in RAPIDS cuDF.

(Note: There is only one maintainer listed for this recipe so I may request to add myself there if it stalls.)