### PR TITLE
Add migration for qt6-main 6.9

### DIFF
--- a/recipe/migrations/qt69.yaml
+++ b/recipe/migrations/qt69.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1744945480
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+qt6_main:
+  - 6.9


### PR DESCRIPTION
I couldn't get  https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1012 to work. i'm pretty sure it is only opencv that needs to be rebuilt, but i could be wrong.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
