### PR TITLE
Add `libpnetcdf` to global pins

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -623,6 +623,8 @@ libparu:
   - '1'
 libpcap:
   - '1.10'
+libpnetcdf:
+  - 1.14.0
 libpng:
   - 1.6
 libprotobuf:


### PR DESCRIPTION
ping @conda-forge/libpnetcdf

There are only a handful of feedstocks using libpnetcdf:
https://github.com/conda-forge/lammps-feedstock/blob/main/recipe/meta.yaml#L87
https://github.com/conda-forge/parallelio-feedstock/blob/main/recipe/meta.yaml#L56
https://github.com/conda-forge/libnetcdf-feedstock/blob/main/recipe/meta.yaml#L86

but it's still proving tedious and sometimes a bit confusing to migrate manually:
https://github.com/conda-forge/parallelio-feedstock/pull/26

This migration is failing because the migration above was missed:
https://github.com/conda-forge/esmf-feedstock/pull/128

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
