### PR TITLE
Add rustac to aarch and arm-osx-64 migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -1085,8 +1085,8 @@ root_pandas
 rosdep
 rosdistro
 rrdtool
-rustac
 ruff
+rustac
 s5cmd
 sage
 sasktran2

--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -1085,6 +1085,7 @@ root_pandas
 rosdep
 rosdistro
 rrdtool
+rustac
 ruff
 s5cmd
 sage

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1487,8 +1487,8 @@ rsync
 rtree
 ruamel.yaml
 rubin-sim
-rustac
 ruff
+rustac
 ruptura
 ruptures
 rust-script

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1487,6 +1487,7 @@ rsync
 rtree
 ruamel.yaml
 rubin-sim
+rustac
 ruff
 ruptura
 ruptures

--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1488,10 +1488,10 @@ rtree
 ruamel.yaml
 rubin-sim
 ruff
-rustac
 ruptura
 ruptures
 rust-script
+rustac
 rustpython
 rvlib
 s2geometry


### PR DESCRIPTION
Kicking off aarch64, ppc64le and arm-osx builds for [rustac](https://github.com/stac-utils/rustac-py).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Addresses https://github.com/stac-utils/rustac-py/issues/40, supersedes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7048