### PR TITLE
Add multinest to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -809,6 +809,7 @@ msitools
 msvc-headers-libs
 mujoco
 multicore-tsne
+multinest
 multiprocess
 mumps
 muspinsim


### PR DESCRIPTION
This PR adds multinest to osx_arm64.txt so that the library can be built for osx-arm64.
