### PR TITLE
add migration for pytorch 2.7

### DIFF
--- a/recipe/migrations/pytorch27.yaml
+++ b/recipe/migrations/pytorch27.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pytorch 2.7
+  kind: version
+  migration_number: 1
+libtorch:
+- '2.7'
+pytorch:
+- '2.7'
+migrator_ts: 1746308782.6617868


### PR DESCRIPTION
Just noticed that we never did the piggyback migrator talked about in #7035 for adding windows support more broadly. We can still do this after this one (and/or wait until our mkl has switched to llvm-openmp).