### PR TITLE
Add mysql_devel to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -743,6 +743,8 @@ mumps_mpi:
   - 5.7.3
 mumps_seq:
   - 5.7.3
+mysql_devel:
+  - 9.0
 nccl:
   - 2
 ncurses:


### PR DESCRIPTION
qt 5.15 is pinned to 9.0 so i figured we would start there

https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Fqt-main-5.15.15-h993ce98_3.conda


I've had trouble manually writing migrations, so i want to let the bot start this one.

cc: @nehaljwani @conda-forge/mysql 
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
