### PR TITLE
Add rav1e 0.7 to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -900,7 +900,7 @@ qt6_main:
 qtkeychain:
   - '0.15'
 rav1e:
-  - '0.6'
+  - '0.7'
 rdma_core:
   - '55'
 re2:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -899,6 +899,8 @@ qt6_main:
   - 6.9
 qtkeychain:
   - '0.15'
+rav1e:
+  - '0.6'
 rdma_core:
   - '55'
 re2:


### PR DESCRIPTION
A new version of rav1e has been released this last year, moving 0.6.6 to 0.7.1

https://github.com/conda-forge/rav1e-feedstock/pull/12

I don't feel like dealing with the fallback from potential ABI compatibility, so I would prefer to tighten the pin and rebuild the (1 ????) feedstock that depends on it, likely https://github.com/conda-forge/libavif-feedstock

However, due to recent binary incompatibility introduced in https://github.com/conda-forge/rav1e-feedstock/issues/13#issuecomment-2852434748 

I'm hoping to skip the step of the migration and move directly to the global pin