### PR TITLE
add less to osx_arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -641,6 +641,7 @@ lazy-object-proxy
 lazydocker
 ldc
 lenstool
+less
 levenshtein
 lfortran
 lftp


### PR DESCRIPTION
Added [less](https://github.com/conda-forge/less-feedstock) as described in the [Knowledge Base - Apple Silicon builds](https://conda-forge.org/docs/maintainer/knowledge_base/#apple-silicon-builds).
