### PR TITLE
remove cython_dev from python313t migrator

### DIFF
--- a/recipe/migrations/python313t.yaml
+++ b/recipe/migrations/python313t.yaml
@@ -32,7 +32,6 @@ __migrator:
         - python_abi
     exclude_pinned_pkgs: false
     additional_zip_keys:
-        - channel_sources
         - is_freethreading
         - is_abi3
     wait_for_migrators:
@@ -43,8 +42,6 @@ __migrator:
 
 python:
 - 3.13.* *_cp313t
-channel_sources:
-- conda-forge/label/cython_dev,conda-forge
 # additional entries to add for zip_keys
 numpy:
 - 2


### PR DESCRIPTION
Pulled forward from #6673; now that cython 3.1.0 has been released, we don't need the `cython_dev` label for freethreading support anymore.