### PR TITLE
Migrate r-gsl to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1332,6 +1332,7 @@ r-ggpubr
 r-glassofast
 r-gmm
 r-gmp
+r-gsl
 r-gsw
 r-gtools
 r-gunifrac


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Will try to migrate more osx-arm64 packages used in bioinformatics, starting with `r-gsl` as it was the bottleneck.