### PR TITLE
[WIP] Add CUDA 11.8 manual migrator

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 rules:
   document-start: disable
   line-length:
-    max: 180
+    max: 260
   indentation:
     spaces: consistent
     indent-sequences: whatever

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -1,0 +1,61 @@
+migrator_ts: 1748496951
+__migrator:
+  kind:
+    version
+  # Use migrator to readd CUDA 11.
+  use_local: true
+  migration_number:
+    1
+  build_number:
+    1
+  paused: true
+  override_cbc_keys:
+    - cuda_compiler_stub
+  operation: key_add
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  ordering:
+    cuda_compiler:
+      - None
+      - cuda-nvcc
+      - nvcc
+    cuda_compiler_version:
+      - None
+      - 12.4
+      - 12.6
+      - 12.8
+      - 12.9
+      - 11.8
+
+cuda_compiler:              # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                    # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version:      # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.8                    # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cuda_compiler_version_min:  # [linux or win64]
+  - 11.8                    # [linux or win64]
+
+c_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cxx_compiler_version:       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+fortran_compiler_version:   # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11                      # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+docker_image:                                             # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-") and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  ### Docker images with CUDA 11.8 support
+
+  # CUDA 11.8 builds (only x64 has a DEFAULT_LINUX_VERSION choice; alma9 not available)
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") == "cos7"]
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "ubi8") in ("ubi8", "alma8", "alma9")]
+
+  # CUDA 11.8 arch: native compilation (build == target)
+  - quay.io/condaforge/linux-anvil-aarch64-cuda11.8:ubi8  # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+  - quay.io/condaforge/linux-anvil-ppc64le-cuda11.8:ubi8  # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+
+  # CUDA 11.8 arch: cross-compilation (build != target)
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8   # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]


### PR DESCRIPTION
We are planning to drop CUDA 11.8 from the global pinnings as discussed in issue: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/7404

Following the pattern that we have used in the past to readd old CUDA version like with PR: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1657

Provide a manual migrator that recipe maintainers can use to readd CUDA 11.8 in their feedstocks.