### PR TITLE
Simplify python3 zip by removing pypy and defunct python versions

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -193,7 +193,6 @@ zip_keys:
     - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   -
     - python
-    - python_impl
     - is_python_min
   -
     - libarrow
@@ -851,16 +850,12 @@ pulseaudio_daemon:
 pybind11_abi:
   - 4
 python:
-  # part of a zip_keys: python, python_impl, is_python_min
+  # part of a zip_keys: python, is_python_min
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
   - 3.12.* *_cpython
 python_impl:
-  # part of a zip_keys: python, python_impl, is_python_min
-  - cpython
-  - cpython
-  - cpython
   - cpython
 python_min:
   # minimum supported python version per CFEP-25

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -864,7 +864,7 @@ python_min:
 is_freethreading:
   - false
 is_python_min:
-  # part of a zip_keys: python, python_impl, is_python_min
+  # part of a zip_keys: python, is_python_min
   - true
   - false
   - false

--- a/recipe/migrations/python313.yaml
+++ b/recipe/migrations/python313.yaml
@@ -6,18 +6,11 @@ __migrator:
     primary_key: python
     ordering:
         python:
-            - 3.6.* *_cpython
-            - 3.7.* *_cpython
-            - 3.8.* *_cpython
             - 3.9.* *_cpython
             - 3.10.* *_cpython
             - 3.11.* *_cpython
             - 3.12.* *_cpython
             - 3.13.* *_cp313  # new entry
-            - 3.6.* *_73_pypy
-            - 3.7.* *_73_pypy
-            - 3.8.* *_73_pypy
-            - 3.9.* *_73_pypy
     paused: false
     longterm: true
     pr_limit: 20
@@ -39,7 +32,5 @@ __migrator:
 python:
 - 3.13.* *_cp313
 # additional entries to add for zip_keys
-python_impl:
-- cpython
 is_python_min:
 - false

--- a/recipe/migrations/python313t.yaml
+++ b/recipe/migrations/python313t.yaml
@@ -6,19 +6,12 @@ __migrator:
     primary_key: python
     ordering:
         python:
-            - 3.6.* *_cpython
-            - 3.7.* *_cpython
-            - 3.8.* *_cpython
             - 3.9.* *_cpython
             - 3.10.* *_cpython
             - 3.11.* *_cpython
             - 3.12.* *_cpython
             - 3.13.* *_cp313  # new entry
             - 3.13.* *_cp313t  # new entry
-            - 3.6.* *_73_pypy
-            - 3.7.* *_73_pypy
-            - 3.8.* *_73_pypy
-            - 3.9.* *_73_pypy
     paused: true
     longterm: true
     pr_limit: 20
@@ -43,8 +36,6 @@ __migrator:
 python:
 - 3.13.* *_cp313t
 # additional entries to add for zip_keys
-python_impl:
-- cpython
 is_freethreading:
 - true
 is_python_min:


### PR DESCRIPTION
In the great spirit of shedding mental load, I think it would be great to simplify these migrators and our general python pinnings.

This mostly removes a redundant zip key, and a bunch of old python versions (including pypy) to help keep things understandable for new contributors.

There remains `is_python_min` but I think we can remove that in a different PR to entirely remove the python zip.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
