### PR TITLE
fix cuda_compiler_version_min in CUDA 11.8 migrator

### DIFF
--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -29,6 +29,12 @@ __migrator:
       - None
       - 12.9
       - 11.8
+    cuda_compiler_version_min:
+      - 12.4
+      - 12.6
+      - 12.8
+      - 12.9
+      - 11.8
 
 cuda_compiler:              # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - nvcc                    # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Fix-up for #7472 while applying this to arrow; also needs https://github.com/conda-forge/conda-smithy/pull/2338 to work correctly.