### PR TITLE
start abseil/grpc/protobuf migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto_25Q2.yaml
+++ b/recipe/migrations/absl_grpc_proto_25Q2.yaml
@@ -4,11 +4,17 @@ __migrator:
   kind: version
   migration_number: 1
   exclude:
+    # core deps
     - abseil-cpp
     - grpc-cpp
     - libprotobuf
+    # required for building/testing
     - protobuf
     - re2
+    # bazel stack
+    - bazel
+    - grpc_java_plugin
+    - singlejar
 libabseil:
 - 20250512
 libgrpc:


### PR DESCRIPTION
After getting all the [pieces](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4075#issuecomment-2985692571) in place[^1], including #7473 

Closes #7523 
Closes #7435
Closes #7434
Closes #7403
Closes #7309

[^1]: bazel 6.x will follow, it's only used by two feedstocks that are late in the graph anyway