### PR TITLE
Migrate azure_core_cpp 1.15.0 and latest storage packages

### DIFF
--- a/recipe/migrations/azure_core_cpp_1150.yaml
+++ b/recipe/migrations/azure_core_cpp_1150.yaml
@@ -1,0 +1,21 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure_core_cpp 1.15.0 and latest storage packages
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+azure_core_cpp:
+- 1.15.0
+azure_storage_common_cpp:
+- 12.10.0
+azure_storage_blobs_cpp:
+- 12.13.0
+azure_storage_files_datalake_cpp:
+- 12.12.0
+azure_storage_files_shares_cpp:
+- 12.13.0
+azure_storage_queues_cpp:
+- 12.4.0
+azure_identity_cpp:
+- 1.11.0
+migrator_ts: 1751899047000


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

cc: @h-vetinari, @teo-tsirpanis
xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7490#issuecomment-2981966822, https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6471, https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6638

This is a combined, manual migration for azure-core-cpp 1.15.0 plus all the latest azure-sdk-for-cpp storage packages available from conda-forge. Note that not all of these have been updated ([current azure pins](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L236-L249)), but I left them all in for transparency and also to facilitate future manual migrations.

https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-identity_1.11.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-storage-files-shares_12.13.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-storage-common_12.10.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-core_1.15.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-storage-queues_12.4.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-storage-files-datalake_12.12.0
https://github.com/Azure/azure-sdk-for-cpp/releases/tag/azure-storage-blobs_12.13.0

For any package that hasn't been updated to the latest yet (eg azure-identity-cpp), the plan is to manually update the recipe directly in the bot migration PR.