### PR TITLE
add autorift to arch_rebuild migrations

### DIFF
--- a/recipe/migrations/arch_rebuild.txt
+++ b/recipe/migrations/arch_rebuild.txt
@@ -29,8 +29,8 @@ astra-toolbox
 astropy
 asyncpg
 attr
-autorift
 austin
+autorift
 awkward1
 awscli2
 awscrt


### PR DESCRIPTION
Adds linux-aarch64 builds to the [feedstock](https://github.com/conda-forge/autorift-feedstock) for [autoRIFT](https://github.com/nasa-jpl/autoRIFT)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
