### PR TITLE
Add migration for pybind11-abi 11 and pybind11 3

### DIFF
--- a/recipe/migrations/pybind11_abi11.yaml
+++ b/recipe/migrations/pybind11_abi11.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pybind11 3 and pybind11_abi 11
+  kind: version
+  migration_number: 1
+migrator_ts: 1752454025.946169
+pybind11_abi:
+- '11'


### PR DESCRIPTION
This PR adds the migration from `pybind11-abi` from `4` to `11` . It was manually opened as the bot one was not updating `pybind11-abi` to the correct value, see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7552 . 

As some feedstocks were stuck to numpy 2 until pybind11 3 came out (see https://github.com/conda-forge/conda-forge.github.io/issues/1997#issuecomment-2545698108), this migration will also be able to finally migrate some feedstocks (such as `manif` and `bipedal-locomotion-framework` to numpy 2).

Related context:
* https://github.com/conda-forge/pybind11-feedstock/pull/112
* https://github.com/conda-forge/pybind11-feedstock/issues/77
* https://github.com/conda-forge/pybind11-feedstock/issues/95
* https://github.com/conda-forge/pybind11-feedstock/issues/96

Quoting from the original bot-issued PRs: 

> This migration will impact 71 feedstocks.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
