### PR TITLE
Bump GCC versions in CUDA 12.9 migrator

### DIFF
--- a/recipe/migrations/cuda129.yaml
+++ b/recipe/migrations/cuda129.yaml
@@ -45,10 +45,10 @@ cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and
   - 12.9                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 cxx_compiler_version:          # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 fortran_compiler_version:      # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
Follow-up to #7476, where we already discussed that CUDA 12.8 & 12.9 are compatible with GCC 14 (c.f. #7421). I had not bumped it after encountering issues with GCC 14 on the pytorch feedstock, but it turns out that those are specific to the vendored xnnpack (also occurs on the jaxlib feedstock), and not related to CUDA at all. So let's bump the version here and see how things go.