### PR TITLE
also update cuda_compiler_version_min in CUDA 12.9 migrator

### DIFF
--- a/recipe/migrations/cuda129.yaml
+++ b/recipe/migrations/cuda129.yaml
@@ -44,6 +44,9 @@ __migrator:
 cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 12.9                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
+cuda_compiler_version_min:     # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12.9                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 


### PR DESCRIPTION
As seen in https://github.com/conda-forge/cccl-feedstock/pull/32, we need to ensure that `cuda_compiler_version_min` is a subset of the current set of `cuda_compiler_version` values (both before/after the migration), otherwise things like
```yaml
skip: true  # [cuda_compiler_version != cuda_compiler_version-min]
```
cannot work.

It seems a bit counter to past practice though that we'd have the newest CUDA version as the minimum, though I guess with enhanced compatibility, that's not such a big deal anymore. I'm also hearing that CUDA 13.x is on the horizon, so then 12.9 (or whatever is the last 12.x release) will be long-lived anyway.