### PR TITLE
Migrate azure_core_cpp 1.16.0 and latest storage packages

### DIFF
--- a/recipe/migrations/azure_core_cpp1160.yaml
+++ b/recipe/migrations/azure_core_cpp1160.yaml
@@ -1,0 +1,21 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure_core_cpp 1.16.0 and latest storage packages
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+azure_core_cpp:
+- 1.16.0
+azure_storage_common_cpp:
+- 12.10.0
+azure_storage_blobs_cpp:
+- 12.14.0
+azure_storage_files_datalake_cpp:
+- 12.12.0
+azure_storage_files_shares_cpp:
+- 12.14.0
+azure_storage_queues_cpp:
+- 12.4.0
+azure_identity_cpp:
+- 1.12.0
+migrator_ts: 1752518680.5378659


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Closes #7560
Closes #7589
Closes #7590

cc: @conda-forge/azure-core-cpp, @h-vetinari
xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7529

Bumps core to 1.16.0, identity to 1.12.0 (will need to bump version manually in migration PR), blobs to 12.14.0, and files-shares to 12.14.0