### PR TITLE
add migration for boost 1.88

### DIFF
--- a/recipe/migrations/libboost188.yaml
+++ b/recipe/migrations/libboost188.yaml
@@ -1,0 +1,12 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for libboost 1.88"
+  migration_number: 1
+libboost_devel:
+- "1.88"
+libboost_headers:
+- "1.88"
+libboost_python_devel:
+- "1.88"
+migrator_ts: 1753251695.3315456


### PR DESCRIPTION
We've been on an "migrate every even boost version" rhythm for a while (#6296, #5191, #4961).

After 1.86 caused a bit more breakage than usual, I let some time go by since [v1.88](https://github.com/conda-forge/boost-feedstock/pull/229), so that the ecosystem has some more time to become compatible. Boost v1.89 is already in [beta](https://github.com/boostorg/boost/releases/tag/boost-1.89.0.beta1), so this seems like a reasonable time.

Plus I wanted to wait for a time where the risk of logjams between major migrations is low. Given that abseil's been [running](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7526) for 2 weeks already, and that python 3.14 is [around the corner](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7598), this seems like the best it's going to get for a while.