### PR TITLE
Add nccmp to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -842,6 +842,7 @@ natcap.invest
 nb_conda
 nb_conda_kernels
 ncbi-datasets-cli
+nccmp
 ncdu
 nco
 ncrystal


### PR DESCRIPTION
Doing as instructed here to get nccmp build for osx-arm64: https://conda-forge.org/docs/maintainer/knowledge_base/#apple-silicon-builds

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
