### PR TITLE
Release harfbuzz pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -370,11 +370,8 @@ googleapis_cpp:
   - '0.10'
 graphviz:
   - '13'
-# Harfbuzz guarantees total ABI compatibiblity
-# The first version to have this new ABI pin is 11.0.1
-# https://github.com/conda-forge/harfbuzz-feedstock/pull/125
 harfbuzz:
-  - '11.0.1'
+  - '11'
 hdf4:
   - 4.2.15
 hdf5:


### PR DESCRIPTION
I feel like the old pin 11.0.1 was quite restrictive and harfbuzz has had many releases since.

Most notably 11.3 which adds some new API/ABI

Just wanting this to keep up.

I think we may even be able to remove harfbuzz from the global pins alltogether tbh.

LMK