### PR TITLE
Add dmri-amico to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -298,9 +298,9 @@ divemesh
 djvulibre
 dkh
 dlib-cpp
+dm-tree
 dmri-amico
 dmri-dicelib
-dm-tree
 docker-buildx
 docker-cli
 docker-compose


### PR DESCRIPTION
Howdy, 

I'd like to get [dmri-amico](https://github.com/conda-forge/dmri-amico-feedstock) and the supplemental [dmri-dicelib](https://github.com/conda-forge/dmri-dicelib-feedstock) built for Apple Silicon - thanks!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
