### PR TITLE
Update pin for mumps 5.8.1

### DIFF
--- a/recipe/migrations/mumps581.yaml
+++ b/recipe/migrations/mumps581.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1754801929
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+mumps_mpi:
+  - 5.8.1
+mumps_seq:
+  - 5.8.1


### PR DESCRIPTION
not sure why the bot didn't do this one

related to #6488, I'm not sure if that's relevant to the lack of an automatic migrator