### PR TITLE
close migrations for fmt and spdlog

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -311,7 +311,7 @@ flann:
 flatbuffers:
   - 24.12.23
 fmt:
-  - '10'
+  - '11.2'
 fontconfig:
   - 2
 freetype:
@@ -908,7 +908,7 @@ soapysdr:
 sox:
   - 14.4.2
 spdlog:
-  - '1.13'
+  - '1.15'
 spirv_tools:
   - 2024
 sqlite:

--- a/recipe/migrations/fmt11.yaml
+++ b/recipe/migrations/fmt11.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for fmt 11
-  kind: version
-  migration_number: 1
-fmt:
-- '11'
-migrator_ts: 1720374637.828791

--- a/recipe/migrations/fmt111.yaml
+++ b/recipe/migrations/fmt111.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for fmt 11.1
-  kind: version
-  migration_number: 1
-fmt:
-- '11.1'
-migrator_ts: 1742837847.162359

--- a/recipe/migrations/fmt112.yaml
+++ b/recipe/migrations/fmt112.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for fmt 11.2
-  kind: version
-  migration_number: 1
-fmt:
-- '11.2'
-migrator_ts: 1751282367.8165693

--- a/recipe/migrations/spdlog114.yaml
+++ b/recipe/migrations/spdlog114.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for spdlog 1.14
-  kind: version
-  migration_number: 1
-migrator_ts: 1722204008.301365
-spdlog:
-- '1.14'

--- a/recipe/migrations/spdlog115.yaml
+++ b/recipe/migrations/spdlog115.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for spdlog 1.15
-  kind: version
-  migration_number: 1
-migrator_ts: 1731195190.0405502
-spdlog:
-- '1.15'


### PR DESCRIPTION
This has been a long time coming. A lot of work has gone into the migrations for 11.0, 11.1, 11.2, as well as spdlog 1.14 and 1.15. I've trying to finish these migrations on & off for the last few months, and I think we're at a point where we can pull the trigger. 

I'm suggesting to close these together, because they have become entangled on many feedstocks; below I note which one applies. What remains:

## Possible

* [ ] [fmt] https://github.com/conda-forge/cantera-feedstock/pull/59
* [ ] [fmt, spdlog] https://github.com/conda-forge/cascade-feedstock/pull/30 (blocked on heyoka pin)
* [ ] [fmt] https://github.com/conda-forge/gnuradio-feedstock/pull/298
* [ ] [fmt] https://github.com/conda-forge/intervalxt-feedstock/pull/25 (upstream not compatible yet)

## Awaiting parents

* [ ] flatsurf (depends on intervalxt)
* [ ] gnuradio-funcube (depends on gnuradio)
* [ ] gnuradio-satellites (depends on gnuradio)

## Feedstocks that pin ancient version of spdlog and/or fmt

* [fmt, spdlog] https://github.com/conda-forge/bmf-feedstock/pull/36 (upstream not compatible yet)
* [fmt, spdlog] https://github.com/conda-forge/reaktoro-feedstock/pull/121
* [fmt, spdlog] https://github.com/conda-forge/spiceql-feedstock/pull/31

## Dead feedstock

* [fmt] https://github.com/conda-forge/ecole-feedstock/pull/46
* [fmt] https://github.com/conda-forge/heavydb-ext-feedstock/pull/88
* [spdlog] https://github.com/conda-forge/river-ingester-feedstock/pull/35 (no compatibility with newer arrow)
* [fmt, spdlog] https://github.com/conda-forge/vowpalwabbit-feedstock/pull/88

Closes #7608

CC @conda-forge/fmt @conda-forge/spdlog