### PR TITLE
add next abseil/grpc/protobuf migrator (2025Q3)

### DIFF
--- a/recipe/migrations/absl_grpc_proto_25Q3.yaml
+++ b/recipe/migrations/absl_grpc_proto_25Q3.yaml
@@ -1,0 +1,30 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20250814, libgrpc 1.74 & libprotobuf 6.32.0
+  kind: version
+  migration_number: 1
+  paused: true
+  exclude:
+    # core deps
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    # required for building/testing
+    - protobuf
+    - re2
+    # bazel stack
+    - bazel
+    - grpc_java_plugin
+    - singlejar
+libabseil:
+- 20250814
+libgrpc:
+- "1.74"
+libprotobuf:
+- 6.32.0
+# we need to leave this migration open until we're ready to move the global baseline, see
+# https://github.com/conda-forge/conda-forge.github.io/issues/2467; grpc 1.72 requires 11.0,
+# see https://github.com/grpc/grpc/commit/f122d248443c81592e748da1adb240cbf0a0231c
+c_stdlib_version:   # [osx]
+  - 11.0            # [osx]
+migrator_ts: 1755579905.5999165


### PR DESCRIPTION
Next in line for #4075, still paused while we build out the required dependencies