### PR TITLE
fix python 3.13 build string

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -816,7 +816,7 @@ python:
   - 3.10.* *_cpython
   - 3.11.* *_cpython
   - 3.12.* *_cpython
-  - 3.13.* *_cpython
+  - 3.13.* *_cp313
 python_impl:
   - cpython
 python_min:


### PR DESCRIPTION
Fix-up after #7661, because freshly rerendered feedstocks are running into
```
Could not solve for environment specs
The following package could not be installed
└─ python =3.13 *_cpython does not exist (perhaps a typo or a missing channel).
```