### PR TITLE
drop obsolete wait_for_migrators from python314.yaml

### DIFF
--- a/recipe/migrations/python314.yaml
+++ b/recipe/migrations/python314.yaml
@@ -25,8 +25,6 @@ __migrator:
         - cross-python
         - python_abi
     exclude_pinned_pkgs: false
-    wait_for_migrators:
-        - python313
     ignored_deps_per_node:
         matplotlib:
             - pyqt


### PR DESCRIPTION
minor follow-up to #7598; the 3.13 migration has been closed in #7661