### PR TITLE
fix interaction between migrators for 3.14 and 3.13t

### DIFF
--- a/recipe/migrations/python313t.yaml
+++ b/recipe/migrations/python313t.yaml
@@ -12,6 +12,7 @@ __migrator:
             - 3.12.* *_cpython
             - 3.13.* *_cp313  # new entry
             - 3.13.* *_cp313t  # new entry
+            - 3.14.* *_cp314
     paused: true
     longterm: true
     pr_limit: 20

--- a/recipe/migrations/python314.yaml
+++ b/recipe/migrations/python314.yaml
@@ -1,3 +1,6 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip
 migrator_ts: 1724712607
 __migrator:
     commit_message: Rebuild for python 3.14


### PR DESCRIPTION
Another fixup for #7598. I'm not 100% sure whether @xhochy intentionally chose a timestamp that's one less than the one for 3.13t (or just a C&P+minimal edit), but it makes sense from my POV due to the order of application of the migrators, and how that interacts with
https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/a640b11fff9d6ad307bb000c583c74d09005dca3/recipe/migrations/python313t.yaml#L27-L29

So add a comment explaining this, as well as the missing ordering key in the 3.13t migrator, now that it also gets applied after the 3.14 one.