### PR TITLE
fix interaction between migrators for 3.14 and 3.13t, part 2

### DIFF
--- a/recipe/migrations/python313t.yaml
+++ b/recipe/migrations/python313t.yaml
@@ -28,8 +28,6 @@ __migrator:
     additional_zip_keys:
         - is_freethreading
         - is_abi3
-    wait_for_migrators:
-        - python313
     ignored_deps_per_node:
         matplotlib:
             - pyqt
@@ -43,3 +41,7 @@ is_python_min:
 - false
 is_abi3:
 - false
+# need to add channel_sources because this migrator is ordered after the 3.14 migrator (if present), and the
+# latter currently (until 3.14 GA) extends the zip with that extra key that we therefore need to provide here
+channel_sources:
+- conda-forge


### PR DESCRIPTION
Another follow-up to #7598 and #7680, as testing is ramping up. There aren't that many feedstocks that migrated for 3.13t (all were done manually, because we never started it), but where present, this should still work.