### PR TITLE
add (paused) migrator for 3.14t

### DIFF
--- a/recipe/migrations/python314t.yaml
+++ b/recipe/migrations/python314t.yaml
@@ -46,4 +46,4 @@ is_python_min:
 is_abi3:
 - false
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge,conda-forge/label/python_rc

--- a/recipe/migrations/python314t.yaml
+++ b/recipe/migrations/python314t.yaml
@@ -1,0 +1,49 @@
+migrator_ts: 1755739493
+__migrator:
+    commit_message: Rebuild for python 3.14 freethreading
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314    # new entry
+            - 3.14.* *_cp314t   # new entry
+    paused: true
+    longterm: true
+    pr_limit: 20
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    # if feedstock already has 3.13t migrator this is redundant, but harmless
+    additional_zip_keys:
+        - is_freethreading
+        - is_abi3
+    wait_for_migrators:
+        - python314
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+
+python:
+- 3.14.* *_cp314t
+# additional entries to add for zip_keys
+is_freethreading:
+- true
+is_python_min:
+- false
+is_abi3:
+- false
+channel_sources:
+- conda-forge/label/python_rc,conda-forge


### PR DESCRIPTION
After #7598, add a 3.14t migrator like we did for 3.13 (#6357) as well; even though that migrator was never started (c.f. #6673)

We [discussed](https://github.com/conda-forge/conda-forge.github.io/blob/68cd44f8cceb4a3b3c09d2c1fd8f75f82f9d7378/community/minutes/2025-08-20.md?plain=1#L66-L69) today that we'll likely start the 3.14t migration towards the end of the year. The reason I think we should add the migrator now already, is that we have a [handful](https://github.com/search?q=org%3Aconda-forge+path%3A.ci_support%2Fmigrations%2Fpython313t.yaml&type=code) of feedstocks that manually added the 3.13t migration, and I think it would only be natural for those feedstocks to _keep_ supporting the freethreading builds also for 3.14t -- numpy being a good example here.

By providing the migrator in the pinning (though again paused, like 3.13t), we make it easy to extend the matrix of a given feedstock to also build for 3.14t, and this will save us (and the feedstock maintainers) some work down the line once we start the 3.14t migration in earnest.

The migrator file has been tested in https://github.com/conda-forge/numpy-feedstock/pull/363 to rerender correctly, also in the presence of the other current python migrators (CI is still red because we're waiting for https://github.com/conda-forge/cross-python-feedstock/pull/97 to be able to cross-compile 3.14).