### PR TITLE
change order of channel_sources in python314.yaml

### DIFF
--- a/recipe/migrations/python314.yaml
+++ b/recipe/migrations/python314.yaml
@@ -40,4 +40,4 @@ python:
 is_python_min:
 - false
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge,conda-forge/label/python_rc


### PR DESCRIPTION
Builds of `python` itself is in the main channel, but the rc-builds depend on `_python_rc` from `conda-forge/label/python_rc`. 

The way the channel_sources have been ordered so far seems to have worked by accident; now we get
```
Encountered problems while solving:
  - package python-3.14.0rc2-h5989046_100_cp314 is excluded by strict repo priority
```

Another fixup of #7598