### PR TITLE
Fix pinnings for ppc64le with enabled CUDA

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,7 +17,7 @@ m2w64_c_stdlib_version:        # [win]
   - 12                         # [win]
 c_stdlib_version:              # [unix]
   - 2.17                       # [linux]
-  - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 2.17                       # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 10.13                      # [osx and x86_64]
   - 11.0                       # [osx and arm64]
 cxx_compiler:


### PR DESCRIPTION
Following the merges of https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7660 and https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7653, the rerender of my recipe fails with:

```
ValueError: Variant configuration errors in /home/fs/.cache/conda-smithy/conda_build_config.yaml:
  zip fields in zip_key group frozenset(
    {'cuda_compiler_version',
     'c_stdlib_version',
     'cxx_compiler_version',
     'fortran_compiler_version',
     'c_compiler_version'}
  ) are not all the same length
```

This is due to having two output packages, one without CUDA support but built for all platforms including `linux_ppc64le`, and one with CUDA support but restricted to `linux_64` and `linux_aarch64`. In this edge case, for the `linux_ppc64le` platform, the resulting pinnings are:

```yaml
c_compiler_version:            # [unix]
  - 14                         # [linux]
c_stdlib_version:              # [unix]
  - 2.17                       # [linux]
  - 2.17                       # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
cxx_compiler_version:          # [unix]
  - 14                         # [linux]
fortran_compiler_version:      # [unix or win64]
  - 14                         # [linux]
cuda_compiler_version:
  - None
```

I thus propose using the same selector on `c_stdlib_version` than on other keys to remove the second entry for the `ppc64le` platform:

```yaml
c_stdlib_version:              # [unix]
  - 2.17                       # [linux]
  - 2.17                       # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
  - 10.13                      # [osx and x86_64]
  - 11.0                       # [osx and arm64]
```