### PR TITLE
chore: pause python3.14 migration due to bugs

### DIFF
--- a/recipe/migrations/python314.yaml
+++ b/recipe/migrations/python314.yaml
@@ -16,7 +16,7 @@ __migrator:
             - 3.13.* *_cp313
             - 3.13.* *_cp313t
             - 3.14.* *_cp314  # new entry
-    paused: false
+    paused: true
     longterm: true
     pr_limit: 5
     max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times


### PR DESCRIPTION
We've encountered non-trivial bugs in conda-smithy + rattler build for python 3.14 that we need to fix. This PR pauses the migration to ensure we don't merge bad PRs.

xref: https://github.com/conda-forge/conda-smithy/issues/2366