### PR TITLE
add support for `osx_64` to `temporalio`

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1683,6 +1683,7 @@ tbb
 tblite-python
 tcplotter
 teensy_loader_cli
+temporalio
 tensorboard
 tensorflow-estimator
 termcolor-cpp


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
### Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] ~Bumped the build number (if the version is unchanged)~
* [ ] ~Reset the build number to `0` (if the version changed)~
* [ ] ~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~
* [ ] ~Ensured the license file is being packaged.~

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

### Please add any other relevant info below:

From the checklist above, I've crossed out the items that I believe are not relevant to this change. I was considering my change as well as other, similar merged PRs in repo. Please correct me if I'm wrong and anything there needs to be addressed.

I have tested this build locally and it succeeded.
