### PR TITLE
add migration for pytorch 2.8

### DIFF
--- a/recipe/migrations/pytorch28.yaml
+++ b/recipe/migrations/pytorch28.yaml
@@ -1,11 +1,9 @@
-migrator_ts: 1756232081
+migrator_ts: 1759338402
 __migrator:
   commit_message: Rebuild for pytorch 2.8
   kind: version
   migration_number: 1
   bump_number: 1
-  wait_for_migrators:
-    - pytorch27
 libtorch:
 - '2.8'
 pytorch:


### PR DESCRIPTION
Adding migration for pytorch 2.8 as it's been out for almost 3 weeks now.

We still have the migration for 2.7 active https://conda-forge.org/status/migration/?name=pytorch27 so I've pinned this to wait on that one.

However since those package PRs have been WIP for ~3months, I suspect we should just close out that migration.