### PR TITLE
bump re2 version

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -869,7 +869,7 @@ rav1e:
 rdma_core:
   - '59'
 re2:
-  - 2024.07.02
+  - 2025.08.12
 readline:
   - "8"
 rocksdb:


### PR DESCRIPTION
We can do this safely because the SOVERSION stayed the same. Compare #5555, #6516 and the references therein.