### PR TITLE
Add libvpl 2.13 to global pins and 2.15 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -660,6 +660,8 @@ libvigra:
   - '1.12'
 libvips:
   - 8
+libvpl:
+  - '2.13'
 libwebp:
   - 1
 libwebp_base:

--- a/recipe/migrations/libvpl215.yaml
+++ b/recipe/migrations/libvpl215.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1757190286
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libvpl:
+  - 2.15


### PR DESCRIPTION
Library that uses it: https://github.com/conda-forge/ffmpeg-feedstock/pull/279

Recent update: https://github.com/conda-forge/libvpl-feedstock/pull/3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
