### PR TITLE
exclude compiler stack from libxml2 migration

### DIFF
--- a/recipe/migrations/libxml2214.yaml
+++ b/recipe/migrations/libxml2214.yaml
@@ -3,6 +3,12 @@ __migrator:
   commit_message: Rebuild for libxml2 2.14
   kind: version
   migration_number: 1
+  exclude:
+    # break circularity with compiler stack
+    - llvmdev
+    - clangdev
+    - compiler-rt
+    - lld
 libxml2:
 - '2.14'
 libxml2_devel:


### PR DESCRIPTION
The bot gets confused with libxml2 being a dependency of the compiler stack (which in turn is used to build libxml2). This leads to a grid-lock in the [migrator](https://conda-forge.org/status/migration/?name=libxml2214), where all involved feedstocks have the same number of children, and none can be chosen by default to break the tie.

<img width="1598" height="900" alt="image" src="https://github.com/user-attachments/assets/6928f212-f32c-41d8-aad4-8468d7a3ceb7" />

I've fixed this manually, c.f. testing in https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/170 and all the referenced PRs therein.