### PR TITLE
add brotli to pinning; migrate for 1.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -245,6 +245,8 @@ azure_storage_files_shares_cpp:
   - 12.14.0
 azure_storage_queues_cpp:
   - 12.4.0
+brotli:
+  - '1.0'
 bullet_cpp:
   - 3.25
 bzip2:
@@ -444,6 +446,12 @@ libboost_headers:
   - '1.86'
 libboost_python_devel:
   - '1.86'
+libbrotlicommon:
+  - '1.0'
+libbrotlidec:
+  - '1.0'
+libbrotlienc:
+  - '1.0'
 libbtf:
   - '2'
 libcamd:

--- a/recipe/migration_support/packages_to_migrate_together.yaml
+++ b/recipe/migration_support/packages_to_migrate_together.yaml
@@ -2,6 +2,12 @@
 # Currently they need to have the same version
 # Also the run_exports need to be on main package
 
+brotli:
+  - brotli
+  - libbrotlicommon
+  - libbrotlidec
+  - libbrotlienc
+
 coin_or_cbc:
   - coin_or_cbc
   - coincbc

--- a/recipe/migrations/brotli11.yaml
+++ b/recipe/migrations/brotli11.yaml
@@ -1,0 +1,14 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for brotli 1.1
+  kind: version
+  migration_number: 1
+brotli:
+- '1.1'
+libbrotlicommon:
+- '1.1'
+libbrotlidec:
+- '1.1'
+libbrotlienc:
+- '1.1'
+migrator_ts: 1757419361.3423874


### PR DESCRIPTION
brotli has an `'x.x'` run-export, and we've merged v1.1.0 over 2 years [ago](https://github.com/conda-forge/brotli-feedstock/pull/39). However, a lot of packages still depend on v1.0, so let's add that to the pinning and migrate.

CC @conda-forge/brotli