### PR TITLE
include noarch in R migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -4,6 +4,10 @@ __migrator:
   kind: version
   migration_number: 1
   pr_limit: 5
+  primary_key: r_base
+  automerge: True
+  longterm: True
+  include_noarch: True
 migrator_ts: 1750421535.8834505
 r_base:
 - '4.5'


### PR DESCRIPTION
We usually run as `longterm` and need to migrate `noarch` packages. I'm satisfied with all the recipes and runs I've inspected, so I'm good for enabling automerge.

CC: @conda-forge/r

For quick ref, this was the R 4.4 migration:

https://github.com/mfansler/conda-forge-pinning-feedstock/blob/f403d3805e818106bc556fb793916088d58d7683/recipe/migrations/r-base44_and_m2w64-ucrt.yaml