### PR TITLE
Enable CUDA 13.0 migrator

### DIFF
--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -5,7 +5,7 @@ __migrator:
     1
   build_number:
     1
-  paused: true
+  paused: false
   override_cbc_keys:
     - cuda_compiler_stub
   check_solvable: false


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Following https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7653, we are now ready to begin the CUDA 13.0 migration.
