### PR TITLE
Manually start vtk951 (vtk 9.5.1) migration

### DIFF
--- a/recipe/migrations/vtk951.yaml
+++ b/recipe/migrations/vtk951.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.5.1"
+  migration_number: 1
+migrator_ts: 1757659579.4736397
+vtk_base:
+- 9.5.1
+vtk:
+- 9.5.1


### PR DESCRIPTION
For some reason I do not fully understand, automatic migrations do not start for vtk. vtk 9.5.0 was released in June 2025, while the vtk 9.4.2 migration was closed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7412/files, so now it is time for migrating to vtk 9.5.1, see also https://github.com/conda-forge/vtk-feedstock/issues/394 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
