### PR TITLE
Pause R migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -3,6 +3,7 @@ __migrator:
   commit_message: Rebuild for r_base 4.5
   kind: version
   migration_number: 1
+  paused: true
   pr_limit: 5
   primary_key: r_base
   automerge: true


### PR DESCRIPTION
Conda-forge CI is backed up currently because the R migrator is chewing through a lot of feedstocks on automerge, paired with some other big hits like the CUDA 13.0 migration starting. Pause R migration for a little while until things calm down.

CC @mfansler