### PR TITLE
pause flang migration

### DIFF
--- a/recipe/migrations/flang19.yaml
+++ b/recipe/migrations/flang19.yaml
@@ -2,6 +2,7 @@ __migrator:
   kind: version
   migration_number: 2
   build_number: 1
+  paused: true
   commit_message: |
     Rebuild for flang 19
     
@@ -60,6 +61,7 @@ __migrator:
     - r-cluster
     - r-clustercrit
     - r-cmprsk
+    - r-conquer
     - r-copula
     - r-coxboost
     - r-coxphf
@@ -172,6 +174,7 @@ __migrator:
     - r-rstpm2
     - r-rxode
     - r-rxode2
+    - r-sctransform
     - r-seriation
     - r-sgeostat
     - r-signal


### PR DESCRIPTION
The flang 19 migration got stuck on a few things, notably https://github.com/conda-forge/flang-activation-feedstock/issues/14. That will take a while to fix yet, and I think we'll do flang 21 in the meantime anyway. But for now, it's mostly pointless to continue the flang 19 migration, so pause it.