### PR TITLE
unpause R migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -3,8 +3,7 @@ __migrator:
   commit_message: Rebuild for r_base 4.5
   kind: version
   migration_number: 1
-  paused: true
-  pr_limit: 5
+  pr_limit: 3
   primary_key: r_base
   automerge: true
   longterm: true


### PR DESCRIPTION
Follow-up to #7773. The queue has finally cleared again. Restart R migration, but reduce velocity some more.