### PR TITLE
restart python 3.14 migration due bytecode invalidation in rc3

### DIFF
--- a/recipe/migrations/python314.yaml
+++ b/recipe/migrations/python314.yaml
@@ -4,7 +4,7 @@
 migrator_ts: 1724712607
 __migrator:
     commit_message: Rebuild for python 3.14
-    migration_number: 1
+    migration_number: 2
     operation: key_add
     primary_key: python
     ordering:


### PR DESCRIPTION
I dislike bumping `migration_number:`s, because it makes the mechanics of "when/how does this migrator apply" much less obvious for maintainers.

However, in this case I think our hands are tied. Python has compiled bytecode (`.pyc` files) which contain a magic number that determines whether they're consumable for a given runtime. In 3.14.0rc3 this magic number was [bumped](https://discuss.python.org/t/python-3-14-0rc3-is-go/103815) _again_ (after we had already waited for rc2 because that also bumped it).

This doesn't break the existing artefacts, but it invalidates their bytecode, meaning any user of py314 that downloads one of the packages with the old magic number will have to wait while a bunch of code gets recompiled, which will be quite visible as a regression of start-up time in a new environment.

Since we're expressly publishing builds intended to be compatible with 3.14 GA already, the only way to ensure that we have a clean set of packages is to rebuild everything. This is painful now, but will only get more painful in the future, so let's bite the bullet sooner rather than later.

Draft until https://github.com/conda-forge/python-feedstock/pull/814 is in.

CC @conda-forge/core
