### PR TITLE
marginally increase max_solver_attempts for R migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -5,6 +5,7 @@ __migrator:
   migration_number: 1
   pr_limit: 3
   primary_key: r_base
+  max_solver_attempts: 5
   automerge: true
   longterm: true
   include_noarch: true


### PR DESCRIPTION
The R migration has been stuck on `r-curl` (and `r-askpass`) for more than a week, due to running out of its `max_solver_attempts:` budget for those feedstocks with spurious failures. For more details (and a proposed solution), see https://github.com/regro/cf-scripts/issues/4749

Increase the number of attempts a bit to unblock these areas of the graph.