### PR TITLE
exclude manually-migrated `r-curl` from `r_base45` migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -9,6 +9,9 @@ __migrator:
   automerge: true
   longterm: true
   include_noarch: true
+  exclude:
+    # manually migrated
+    - r-curl
 migrator_ts: 1750421535.8834505
 r_base:
 - '4.5'


### PR DESCRIPTION
I manually migrated `r-curl`, but it's not getting updated in the **r_base45** migration DAG, so proposing we exclude, similar to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7755.

CC: @h-vetinari 

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
