### PR TITLE
increase velocity of R 4.5 migration

### DIFF
--- a/recipe/migrations/r_base45.yaml
+++ b/recipe/migrations/r_base45.yaml
@@ -3,7 +3,7 @@ __migrator:
   commit_message: Rebuild for r_base 4.5
   kind: version
   migration_number: 1
-  pr_limit: 3
+  pr_limit: 20
   primary_key: r_base
   max_solver_attempts: 5
   automerge: true


### PR DESCRIPTION
The py3.14 migration has a pretty low volume of PRs at the moment (as long as we don't do #7795), so let's use that time to clear a bit of the R migration backlog.

CC @conda-forge/r