### PR TITLE
Add btrees to osx-arm64 migration

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -114,6 +114,7 @@ brian2
 brotlipy
 bsddb3
 bt
+btrees
 buildbot
 bytewax
 cached_interpolate


### PR DESCRIPTION
Add btrees to osx-arm64 migration

* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)


