### PR TITLE
DOC: Remove mention of torch list from migration

### DIFF
--- a/recipe/migrations/cuda129.yaml
+++ b/recipe/migrations/cuda129.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    1
+    2
   build_number:
     1
   paused: false
@@ -33,8 +33,8 @@ __migrator:
     for their package. A good balance between broad support and storage
     footprint (resp. compilation time) is to add `sm_100` and `sm_120`.
     
-    Since CUDA 12.8, the conda-forge nvcc package now sets `CUDAARCHS` and
-    `TORCH_CUDA_ARCH_LIST` in its activation script to a string containing all
+    Since CUDA 12.8, the conda-forge nvcc package now sets `CUDAARCHS`
+    in its activation script to a string containing all
     of the supported real architectures plus the virtual architecture of the
     latest. Recipes for packages who use these variables to control their build
     but do not want to build for all supported architectures will need to override

--- a/recipe/migrations/cuda129.yaml
+++ b/recipe/migrations/cuda129.yaml
@@ -3,7 +3,7 @@ __migrator:
   kind:
     version
   migration_number:
-    2
+    1
   build_number:
     1
   paused: false

--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -2,7 +2,7 @@ migrator_ts: 1755016036
 __migrator:
   operation: key_add
   migration_number:
-    1
+    2
   build_number:
     1
   paused: false

--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -2,7 +2,7 @@ migrator_ts: 1755016036
 __migrator:
   operation: key_add
   migration_number:
-    2
+    1
   build_number:
     1
   paused: false

--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -33,7 +33,7 @@ __migrator:
     for their package.
 
     Since CUDA 12.8, the conda-forge nvcc package now sets `CUDAARCHS` and
-    `TORCH_CUDA_ARCH_LIST` in its activation script to a string containing all
+    in its activation script to a string containing all
     of the supported real architectures plus the virtual architecture of the
     latest. Recipes for packages who use these variables to control their build
     but do not want to build for all supported architectures will need to override


### PR DESCRIPTION
The nvcc packages will no longer set TORCH_CUDA_ARCH_LIST in an activation script because pytorch explicitly checks whether the provided archs are valid. This causes the list from new compilers to be incompatible with older versions of pytorch when the list contains very new archs.

https://github.com/conda-forge/cuda-nvcc-feedstock/pull/80
https://github.com/conda-forge/cuda-nvcc-feedstock/pull/79

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
