### PR TITLE
DISCUSS: use clang 20

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,7 +4,7 @@ c_compiler:
   - vs2022                     # [win]
 c_compiler_version:            # [unix]
   - 14                         # [linux]
-  - 19                         # [osx]
+  - 20                         # [osx]
   # CUDA 12.6 doesn't support GCC 14
   - 13                         # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 c_stdlib:
@@ -26,10 +26,10 @@ cxx_compiler:
   - vs2022                     # [win]
 cxx_compiler_version:          # [unix]
   - 14                         # [linux]
-  - 19                         # [osx]
+  - 20                         # [osx]
   - 13                         # [linux and not ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 llvm_openmp:                   # [osx]
-  - 19                         # [osx]
+  - 20                         # [osx]
 fortran_compiler:              # [unix or win64]
   - gfortran                   # [linux64 or (osx and x86_64)]
   - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]


### PR DESCRIPTION
Clang has a 6 month release cadence, and the last few years we've updated to an even release in the fall (#6571, #4991, #3261, #2010).

In particular, development on LLVM 19 has stopped completely. The same is true for LLVM 20 actually, but at least it contains 6 months more of features & fixes. Upstream is currently doing point-releases for 21.x, which will stop with the release of v22 early next year. We can then do a bump to GCC 15 & Clang 21 in the spring again (after the release of GCC 16 resp. the corresponding 15.x point-release).

## However, due to two ABI breaks in LLVM v20.1, we might want to skip this release

Also, one of the two ABI breaks might need a more comprehensive rebuild anyway (hopefully not "full rebuild..."). This PR is for discussion purposes, and remains a draft until these points are resolved one way or another.

### To-Do list based on [docs](https://conda-forge.org/docs/maintainer/infrastructure/#compilers-and-runtimes)

* [x] Update all respective feedstocks (listing only those for activation; they wouldn't pass if the implementation wasn't complete)
  * [x] https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/165 (osx)
  * [x] https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/148 (linux; not part of global pinning)
  * [x] https://github.com/conda-forge/clang-win-activation-feedstock/pull/51 (win; not part of the global pinning)
  * [x] https://github.com/conda-forge/r_clang_activation-feedstock/pull/9 (clang for r-feedstocks; not part of global pinning)
* [x] Tested that compilers work
  * https://github.com/conda-forge/scipy-feedstock/pull/250
* [x] Checked release notes for ABI-relevant changes
  * [x] Clang [potentially breaking changes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes)
    * Minor changes for overflow handling
  * [x] Clang & libcxx [ABI changes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version)
    * **[likely problematic]** https://github.com/llvm/llvm-project/issues/108015:
      > Fixed the Itanium mangling of the construction vtable name. This change will introduce incompatibilities with code compiled by Clang 19 and earlier versions, unless the -fclang-abi-compat=19 option is used.
      
      I don't know what a "construction vtable" is, but vtables are very common, so we might have to do a bigger rebuild, or permanently add `-fclang-abi-compat=19` to the compiler flags, which also isn't a very appealing idea.
    * **[potentially problematic]** https://github.com/llvm/llvm-project/issues/154985:
      I don't remember seeing any issues related to this when we released `libcxx v20.1`; OTOH, we [split](https://github.com/conda-forge/clangdev-feedstock/issues/310#issuecomment-2330421676) the libcxx headers from the library about a year ago, and `clangxx` now always brings a matching `libcxx-devel`. This could mean that using libcxx 20 headers at compile-time and libcxx 21 at runtime would surface the ABI break (and inversely, that we've never encountered the ABI break because the libcxx 20 headers were never in use at scale).
      
      In the referenced issue, the LLVM maintainers were discussing the possibility of an LLVM v20.2 release, i.e. one including a backport of https://github.com/llvm/llvm-project/commit/f5e687d7bf49cd9fe38ba7acdeb52d4f30468dee, but that seems to have fizzled out and realistically won't happen.
    * Other minor changes of the kind we had ignored in [19](https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [18](https://releases.llvm.org/18.1.8/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [17](https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [16](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [15](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-clang) & [14](https://releases.llvm.org/14.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-clang)

Previously: #7421 #6571 #4890 #4991 #4215 #3731 #3290 #3261 #2802 #2010 

CC @conda-forge/core