### PR TITLE
Add `clang_compiler` and `gcc_compiler` convenience entries

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,7 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
   - vs2022                     # [win]
+# Please remember to update gcc_compiler_version & clang_compiler_version too.
 c_compiler_version:            # [unix]
   - 14                         # [linux]
   - 19                         # [osx]
@@ -24,6 +25,7 @@ cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
   - vs2022                     # [win]
+# Please remember to update gxx_compiler_version & clangxx_compiler_version too.
 cxx_compiler_version:          # [unix]
   - 14                         # [linux]
   - 19                         # [osx]


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add entries to enable explicit `compiler('clang')` and `compiler('gcc')` macro usage.  As discussed in conda-forge/conda-forge.github.io#2596, these currently work incidentally, but could be used as a convenient method of forcing GCC or Clang for a particular package.

This involves a slight change in behavior — whereas previously the implicit behavior would only activate a C compiler, it now activates both C and C++ compilers.  Furthermore, `compiler('clang')` defaults to using `clang-cl` on Windows, making the behavior more consistent with the MSVC usage in the default compiler set.

There is currently one feedstock (conda-forge/python-poppler-feedstock) that uses `compiler('clang')` and will need to be tested with the change.  A quick search reveals no uses of `compiler('gcc')`.

CC @h-vetinari, @isuruf 