### PR TITLE
stay on OpenSSL LTS version in pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -774,8 +774,10 @@ openmpi:
   - 4
 openslide:
   - 4
+# although openssl follows SemVer for ABI/API stability, we stay on
+# LTS version at build time to avoid forcing newer version at runtime
 openssl:
-  - '3'
+  - '3.5'
 orc:
   - 2.2.1
 pango:


### PR DESCRIPTION
OpenSSL changed it's versioning scheme with 3.0, committing to API/ABI stability across the entire major line. We've been making use of that and I'm not aware of any breakage that occurred between versions.

However, using
```yaml
host:
  - openssl
```
causes a run-export of `openssl >=3.x,<4`, and so a bare `'3'` pin causes us to _require_ the newest openssl minor version across our entire stack. This makes it essentially impossible for someone wanting to use conda-forge to stay on an LTS version (or rather, you get a frozen set of dependencies and more and more conflicts over time). For example, Anaconda has stayed on 3.0 (the previous LTS version) for its pinning, presumably due to the same line of reasoning.

Of course, one can make the argument that conda-forge doesn't need to care about what anyone else is doing, and in some situations I'm more than happy to make that case. Here however, we don't gain anything by forcing the newest minor version, in the sense that, with this PR:
* packages will still pull in openssl 3.6 at runtime
* additionally, use of openssl 3.5 LTS becomes feasible for those that need it
* if a package _requires_ to be built against openssl 3.6, that's still possible on a per-feedstock basis

The non-LTS minor versions now also have a [reduced](https://openssl-library.org/roadmap/index.html) support window of 13 month, which further makes the case for this IMO.

I'm waiting with merging https://github.com/conda-forge/openssl-feedstock/pull/215 until this PR is merged (or the approach is rejected by consensus).

CC @conda-forge/openssl