### PR TITLE
Add 0.11 pin to osqp-eigen

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -804,6 +804,8 @@ openssl:
   - '3.5'
 orc:
   - 2.2.1
+osqp_eigen:
+  - '0.11'
 pango:
   - '1'
 pari:


### PR DESCRIPTION
The `osqp-eigen` C++ library is a shared library with run_exports. It is now used in ~5 feedstocks, so it is useful to have it as a global pinning. I already verified manually that all the feedstocks have been rebuild with `osqp-eigen==0.11.*`, so I think we can just fix the pin to 0.11 directly without creating a migration.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
