### PR TITLE
add migration for cudnn 9.10

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -176,6 +176,12 @@ zip_keys:
     # CUDA 13.x requires newer glibc than our current baseline
     - c_stdlib_version          # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    # temporarily due to https://github.com/conda-forge/cudnn-feedstock/issues/124
+    - cudnn                     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  -                             # [win and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    # temporarily due to https://github.com/conda-forge/cudnn-feedstock/issues/124
+    - cuda_compiler_version     # [win and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cudnn                     # [win and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   -
     - python
     - is_python_min
@@ -301,8 +307,10 @@ coin_or_utils:
   - 2.11
 console_bridge:
   - 1.0
+# temporarily zipped with cuda_compiler_version
 cudnn:
-  - '9'
+  - None
+  - '9'     # [((linux and not ppc64le) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cutensor:
   - 2
 curl:

--- a/recipe/migrations/cuda118.yaml
+++ b/recipe/migrations/cuda118.yaml
@@ -48,6 +48,9 @@ cuda_compiler_version:      # [(linux or win64) and os.environ.get("CF_CUDA_ENAB
 cuda_compiler_version_min:  # [linux or win64]
   - 11.8                    # [linux or win64]
 
+cudnn:                      # [linux or win64]
+  - 9                       # [linux or win64]
+
 c_stdlib_version:           # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 2.17                    # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 

--- a/recipe/migrations/cuda129.yaml
+++ b/recipe/migrations/cuda129.yaml
@@ -51,6 +51,9 @@ cuda_compiler_version_min:     # [((linux and (x86_64 or aarch64)) or win64) and
 c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 2.17                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
+cudnn:                         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 9                          # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 

--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -52,6 +52,9 @@ cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and
 c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 2.28                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
+cudnn:                         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 9                          # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 

--- a/recipe/migrations/cudnn910.yaml
+++ b/recipe/migrations/cudnn910.yaml
@@ -1,0 +1,34 @@
+# needs to be ordered before CUDA 13.0 migrator
+migrator_ts: 1755016000
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+  ordering:
+    cudnn:
+      - None
+      - 9
+      - 9.10
+  commit_message: |
+    Rebuild for cudnn 9.10
+    
+    Conda-forge assumed cudnn 9.x builds would stay compatible with each other.
+    This is the case for the API/ABI of the library, but nvidia dropped support
+    for older GPU architectures in cudnn 9.11. Since we have no package-level
+    metadata about compatibility with specific GPU architectures, this effectively
+    breaks all packages built atop cudnn for users on affected older GPUs.
+    
+    In order to remedy this situation, we need to rebuild all cudnn-dependent
+    feedstocks against cudnn 9.10 (the last version with full architecture support),
+    before we mark all those newer cudnn builds as broken. This only affects artefacts
+    for CUDA 12.x; those for CUDA 13.x are not affected, since CUDA 13 never supported
+    those older architectures in the first place.
+    
+    For more details see: https://github.com/conda-forge/cudnn-feedstock/issues/124
+
+cudnn:
+  - None
+  - 9.10                       # [((linux and not ppc64le) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
For https://github.com/conda-forge/cudnn-feedstock/issues/124, after the back and forth with https://github.com/conda-forge/admin-requests/pull/1687 & https://github.com/conda-forge/admin-requests/pull/1715.

Rebuilding CUDA 12.x with cudnn 9.10 will ensure everything is functional when we actually mark the newer cudnn builds as broken (i.e. redo https://github.com/conda-forge/admin-requests/pull/1687).

Once that's done, we can remove cudnn from the zip again, and let the pin float back to `9`. 

I've tested this in https://github.com/conda-forge/pytorch-cpu-feedstock/pull/432 & also on a feedstock with CUDA 13, see [here](https://github.com/h-vetinari/dlib-feedstock/tree/cudnn).

CC @conda-forge/cudnn