### PR TITLE
AWS C library migration: end of oct'25

### DIFF
--- a/recipe/migrations/aws_c_end_of_oct25.yaml
+++ b/recipe/migrations/aws_c_end_of_oct25.yaml
@@ -1,0 +1,12 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (end of oct'25)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1761731196
+aws_c_cal:
+  - '0.9.6'
+aws_c_http:
+  - '0.10.7'


### PR DESCRIPTION
AWS C library migration for end of oct'25

## Updated packages:
- aws_c_cal: 0.9.6
- aws_c_http: 0.10.7
