### PR TITLE
distinguish osx in mkl migrator

### DIFF
--- a/recipe/migrations/mkl2025.yaml
+++ b/recipe/migrations/mkl2025.yaml
@@ -5,6 +5,8 @@ __migrator:
   migration_number: 1
 migrator_ts: 1731082955.2367358
 mkl:
-- '2025'
+- '2025'  # [not osx]
+- '2023'  # [osx]
 mkl_devel:
-- '2025'
+- '2025'  # [not osx]
+- '2023'  # [osx]


### PR DESCRIPTION
We forgot to do this in #6666, but MKL has dropped support for osx-64 with v2024; we already had the same setup for the last migration
https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/1a3a7cf87751bf71bdf4a3a315a5c23948a45f66/recipe/migrations/mkl2024.yaml#L6-L11