### PR TITLE
pause flang21 migration

### DIFF
--- a/recipe/migrations/flang21.yaml
+++ b/recipe/migrations/flang21.yaml
@@ -2,6 +2,7 @@ __migrator:
   kind: version
   migration_number: 1
   build_number: 1
+  paused: true
   commit_message: |
     Rebuild for flang 21
     


### PR DESCRIPTION
Due to an [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/27353) with CMake compiler detection that seems pretty widespread.