### PR TITLE
Manually close out migration for ffmpeg8

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -326,7 +326,7 @@ exiv2:
 expat:
   - 2
 ffmpeg:
-  - '7'
+  - '8'
 fftw:
   - 3
 flann:

--- a/recipe/migrations/ffmpeg8.yaml
+++ b/recipe/migrations/ffmpeg8.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for ffmpeg 8
-  kind: version
-  migration_number: 1
-ffmpeg:
-- '8'
-migrator_ts: 1755982363.1556034


### PR DESCRIPTION
The current status of the migration is:

<img width="1309" height="547" alt="image" src="https://github.com/user-attachments/assets/22ba52c6-ffa3-4ccc-b178-083bfc69b283" />


The only non-leaf missing PRs are:
* https://github.com/conda-forge/kfilemetadata-feedstock/pull/42
* https://github.com/conda-forge/mlt-feedstock/pull/29

That block the leaf system:
* https://github.com/conda-forge/kdenlive-feedstock

That were not migrated to ffmpeg 5, 6 or 7, so I think it is ok to ignore them.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
