### PR TITLE
deprecate use of posix package on windows

### DIFF
--- a/recipe/linter_hints/hints.toml
+++ b/recipe/linter_hints/hints.toml
@@ -86,6 +86,7 @@ libgfortran-ng = """\
       ignore_run_exports_from:
         - {{ compiler("fortran") }}
     ```"""
+posix = "Use of `posix` package on windows is deprecated. Use `m2-base`."
 magma = "The `magma` output has been superseded by `libmagma-devel`."
 openmp = "The `openmp` output has been superseded by `llvm-openmp`."
 astropy = """\


### PR DESCRIPTION
`posix` package was an artifact of earlier `m2-*` packages. I decided not to port that over to the new packages because it was a weird package name. It was previously a metapackage of m2-base and some other unused `m2-*` packages.