### PR TITLE
Migrate for aws-c-* mid November '25

### DIFF
--- a/recipe/migrations/aws_c_mid_November_25.yaml
+++ b/recipe/migrations/aws_c_mid_November_25.yaml
@@ -1,0 +1,12 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (mid November '25)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1763029850
+aws_c_cal:
+  - '0.9.10'
+aws_crt_cpp:
+  - '0.35.2'


### PR DESCRIPTION
aws-c-* migration for mid November '25

## Updated packages:
- aws_c_cal: 0.9.10
- aws_crt_cpp: 0.35.2
