### PR TITLE
Revert "pause flang21 migration"

### DIFF
--- a/recipe/migrations/flang21.yaml
+++ b/recipe/migrations/flang21.yaml
@@ -2,7 +2,6 @@ __migrator:
   kind: version
   migration_number: 1
   build_number: 1
-  paused: true
   commit_message: |
     Rebuild for flang 21
     


### PR DESCRIPTION
Undo #7915, now that the CMake [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/27353) got fixed by https://github.com/conda-forge/flang-rt-feedstock/pull/12. Tested to work in https://github.com/conda-forge/openmp-feedstock/pull/196