### PR TITLE
break circular dependency between blas/lapack in flang migrator

### DIFF
--- a/recipe/migrations/flang21.yaml
+++ b/recipe/migrations/flang21.yaml
@@ -33,6 +33,8 @@ __migrator:
   override_cbc_keys:
     - fortran_compiler_stub
   exclude:
+    # bot detects a circular dependency between blas and lapack
+    - lapack
     # these packages should be skipped because they're not built on windows, which
     # contradicts platform_allowlist, see https://github.com/regro/cf-scripts/issues/3436
     - mpich


### PR DESCRIPTION
From the POV of the migrator, lapack depends on blas and vice versa

<img width="1607" height="553" alt="514375305-1764bbeb-ec76-46d0-8b1d-6138b9b92a8a" src="https://github.com/user-attachments/assets/f95500c4-e107-4e42-8cc6-9ed66352d4ea" />

We do lapack manually, and skip it from the POV of the migrator.
