### PR TITLE
Add xrayutilities to OSX ARM64 migration support

### DIFF
--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -1852,6 +1852,7 @@ xorg-xineramaproto
 xorjson
 xpa
 xraylib
+xrayutilities
 xsimd
 xsv
 xtb


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Requesting migration of xrayutilities to osx-arm64, related to issue https://github.com/conda-forge/xrayutilities-feedstock/issues/28
