### PR TITLE
add migration for pytorch 2.9

### DIFF
--- a/recipe/migrations/pytorch29.yaml
+++ b/recipe/migrations/pytorch29.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1764149285
+__migrator:
+  commit_message: Rebuild for pytorch 2.8
+  kind: version
+  migration_number: 1
+  bump_number: 1
+libtorch:
+- '2.9'
+pytorch:
+- '2.9'


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/pytorch-cpu-feedstock/pull/448