### PR TITLE
Fix typo on pytorch 2.9 migration commit message

### DIFF
--- a/recipe/migrations/pytorch29.yaml
+++ b/recipe/migrations/pytorch29.yaml
@@ -1,6 +1,6 @@
 migrator_ts: 1764149285
 __migrator:
-  commit_message: Rebuild for pytorch 2.8
+  commit_message: Rebuild for pytorch 2.9
   kind: version
   migration_number: 1
   bump_number: 1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Patches https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7994/files#r2566610182