### PR TITLE
Add migration for libflac 1.5

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -514,6 +514,8 @@ libexactreal:
   - '4'
 libffi:
   - '3.5'
+libflac:
+  - '1.4'
 libflatsurf:
   - 3
 libflint:

--- a/recipe/migrations/libflac15.yaml
+++ b/recipe/migrations/libflac15.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1764526148
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libflac:
+  - '1.5'


### PR DESCRIPTION
it was never added to the global migrators, so packages were never rebuilt in the last year

libsndfile still depends on 1.4