### PR TITLE
Manually start vtk952 (vtk 9.5.2) migration

### DIFF
--- a/recipe/migrations/vtk952.yaml
+++ b/recipe/migrations/vtk952.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.5.2"
+  migration_number: 1
+migrator_ts: 1764622028.4736397
+vtk_base:
+- 9.5.2
+vtk:
+- 9.5.2


### PR DESCRIPTION
For some reason I do not fully understand, automatic migrations do not start for vtk. So similarly to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7771, for vtk 9.5.2 we need to start the migration manually.

@conda-forge/vtk 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
