### PR TITLE
Migrate for aws-c-* dec'25-2

### DIFF
--- a/recipe/migrations/aws_c_dec252.yaml
+++ b/recipe/migrations/aws_c_dec252.yaml
@@ -1,0 +1,16 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (dec'25-2)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1764938147
+aws_c_auth:
+  - '0.9.3'
+aws_c_event_stream:
+  - '0.5.7'
+aws_c_s3:
+  - '0.11.3'
+s2n:
+  - '1.6.2'


### PR DESCRIPTION
aws-c-* migration for dec'25-2

## Updated packages:
- aws_c_auth: 0.9.3
- aws_c_event_stream: 0.5.7
- aws_c_s3: 0.11.3
- s2n: 1.6.2
