### PR TITLE
Migrate for aws-c-* dec'25-3

### DIFF
--- a/recipe/migrations/aws_c_dec253.yaml
+++ b/recipe/migrations/aws_c_dec253.yaml
@@ -1,0 +1,16 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (dec'25-3)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1764938290
+aws_c_auth:
+  - '0.9.3'
+aws_c_event_stream:
+  - '0.5.7'
+aws_c_s3:
+  - '0.11.3'
+s2n:
+  - '1.6.2'


### PR DESCRIPTION
aws-c-* migration for dec'25-3

## Updated packages:
- aws_c_auth: 0.9.3
- aws_c_event_stream: 0.5.7
- aws_c_s3: 0.11.3
- s2n: 1.6.2
