### PR TITLE
easychem osx arm build

### DIFF
--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -1896,3 +1896,4 @@ zip
 zodbpickle
 zopfli
 zoxide
+easychem


### PR DESCRIPTION
Adding osx-arm build for the easychem package (https://github.com/conda-forge/easychem-feedstock)