### PR TITLE
Pin geos to 3.14.1, current release

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -369,7 +369,7 @@ libgdal:
 libgdal_core:
   - '3.11'
 geos:
-  - 3.14.0
+  - 3.14.1
 geotiff:
   - '1.7'
 gfal2:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
*  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
*  Ensured the license file is being packaged.

I believe #8050 mistakenly downgraded geos to 3.14.0 as an older migration was closed out after the latest migration