### PR TITLE
add migration for openvino 2025.3

### DIFF
--- a/recipe/migrations/openvino202530.yaml
+++ b/recipe/migrations/openvino202530.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1765849200.9674282
+__migrator:
+  kind: version
+  commit_message: Rebuild for libopenvino 2025.3.0
+  migration_number: 1
+  bump_number: 1
+libopenvino_dev:
+  - 2025.3.0


### PR DESCRIPTION
Bot doesn't do migrations for openvino automatically for some reason; do it manually (c.f. #7274 most recently). 2025.4 is almost done already, but this is necessary to rebuild openvino-tokenizers etc.

CC @conda-forge/openvino