### PR TITLE
Migrate for aws-c-* mid-dec'25

### DIFF
--- a/recipe/migrations/aws_c_middec25.yaml
+++ b/recipe/migrations/aws_c_middec25.yaml
@@ -1,0 +1,20 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (mid-dec'25)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1765876371
+aws_c_auth:
+  - '0.9.4'
+aws_c_event_stream:
+  - '0.5.9'
+aws_c_io:
+  - '0.24.0'
+aws_checksums:
+  - '0.2.8'
+aws_crt_cpp:
+  - '0.36.0'
+s2n:
+  - '1.6.3'


### PR DESCRIPTION
aws-c-* migration for mid-dec'25

## Updated packages:
- aws_c_auth: 0.9.4
- aws_c_event_stream: 0.5.9
- aws_c_io: 0.24.0
- aws_checksums: 0.2.8
- aws_crt_cpp: 0.36.0
- s2n: 1.6.3
