### PR TITLE
add migration for openvino 2025.4.1

### DIFF
--- a/recipe/migrations/openvino202540.yaml
+++ b/recipe/migrations/openvino202540.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1766013698.859461
+__migrator:
+  kind: version
+  commit_message: Rebuild for libopenvino 2025.4.1
+  migration_number: 1
+  bump_number: 1
+libopenvino_dev:
+  - 2025.4.1


### PR DESCRIPTION
Like #8068; pending https://github.com/conda-forge/openvino-feedstock/issues/141 and/or a rebuild of openvino for 2025.4.1