### PR TITLE
Add osx-arm64, linux-aarch64 and linux-ppc64le builds for laura

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -375,6 +375,7 @@ lap
 lapack
 lasagne
 laspy
+laura
 lazrs-python
 lazydocker
 lbaplocal

--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -660,6 +660,7 @@ landlab
 lap
 lapack
 laspy
+laura
 lazrs-python
 lazy-object-proxy
 lazydocker


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

Add laura package to migration support for osx-arm64, linux-aarch64 and linux-ppc64le builds.