### PR TITLE
allow DEFAULT_LINUX_VERSION=alma10

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -170,6 +170,11 @@ docker_image:                                       # [os.environ.get("BUILD_PLA
   - quay.io/condaforge/linux-anvil-aarch64:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
   - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma9"]
 
+  # builds on AlmaLinux 10
+  - quay.io/condaforge/linux-anvil-x86_64:alma10    # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma10"]
+  - quay.io/condaforge/linux-anvil-aarch64:alma10   # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma10"]
+  - quay.io/condaforge/linux-anvil-ppc64le:alma10   # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") == "alma10"]
+
 zip_keys:
   -                             # [unix]
     - c_compiler_version        # [unix]


### PR DESCRIPTION
This doesn't change the default, but it allows feedstocks to choose the images that go together with the 2.39 sysroot where necessary by adding
```yaml
os_version:
  linux_64: alma10
  linux_aarch64: alma10
  linux_ppc64le: alma10
```
to `conda-forge.yml` (instead of doing gymnastics with overriding `docker_images` correctly).

Xref:
- https://github.com/conda-forge/docker-images/pull/319
- https://github.com/conda-forge/linux-sysroot-feedstock/pull/92
- https://github.com/conda-forge/conda-forge.github.io/issues/2657