### PR TITLE
Add heppdt to arm migrations

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -316,6 +316,7 @@ healpix_cxx
 heaptrack
 heffte
 hepmc3
+heppdt
 heyoka
 heyoka.py
 hmmlearn

--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -559,6 +559,7 @@ heffte
 helios
 helix
 help2man
+heppdt
 heyoka
 heyoka.py
 hf-transfer


### PR DESCRIPTION
Add heppdt to the osx-arm64 and linux-aarch64 arch rebuild migration lists.