### PR TITLE
Add mysql 9.6 migration

### DIFF
--- a/recipe/migrations/mysql_devel96.yaml
+++ b/recipe/migrations/mysql_devel96.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for mysql_devel 9.6
+  kind: version
+  migration_number: 1
+
+mysql_devel:
+- '9.6'
+migrator_ts: 1772123601.000000


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
*  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
*  Ensured the license file is being packaged.

It is unclear to me if this package still needs to be manually migrated, but I did the work, so here I am :)  cc: @hmaarrfk 