### PR TITLE
Add wasmtime-py to osx-arm64 and linux-aarch64 migrations

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -1325,6 +1325,7 @@ vowpalwabbit
 vtk
 vulkan-loader
 wabt
+wasmtime-py
 watchfiles
 web3
 wgrib2

--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -1858,6 +1858,7 @@ vowpalwabbit
 vpython
 vulkan-loader
 wabt
+wasmtime-py
 watchfiles
 wcslib
 web3


### PR DESCRIPTION
This enables osx-arm64 (Apple Silicon) and linux-aarch64 native builds for wasmtime-py.