### PR TITLE
remove temporary workaround that was conditionally skipping test_migrations.py

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,7 @@ test:
     - test -f $PREFIX/share/conda-forge/migrations/example.exyaml     # [unix]
     - test -d $PREFIX/share/conda-forge/migration_support             # [unix]
     - export GIT_REPO_LOC={{ os.environ.get("FEEDSTOCK_ROOT", "") }}  # [unix]
-{% if not version.startswith("2025.12.15") %}
     - pytest -vvs test_migrations.py                                  # [unix]
-{% endif %}
 
 about:
   summary: The baseline versions of software for the conda-forge ecosystem


### PR DESCRIPTION
This is causing a nuisance linter message

> The recipe is not parsable by parser `conda-recipe-manager`. The recipe can only be automatically migrated to the new v1 format if it is parseable by conda-recipe-manager.

These were added in #8064 and don't seem necessary anymore. In other cases of this, I've been able to make the linter happy by putting jinja or yaml comment lines at the same indentation of whatever section they're in (I think c-r-m has its own finicky yaml parser implementation)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
