### PR TITLE
Just pin the major version of assimp to 6

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -232,7 +232,7 @@ arb:
 arpack:
   - '3.9'
 assimp:
-  - 6.0.3
+  - 6
 attr:
   - 2.5
 aws_c_auth:


### PR DESCRIPTION
The 6.* series of release of assimp has been ABI stable, they indeed use the major version of the library as soversion, and linux distributions packaging such as Debian and Ubuntu package the library as `libassimp6`, indeed assuming the ABI stability for the major release.

For this reason, as discussed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8172#issuecomment-4362013960 I think it make sense to:
* [x] Relax the run_exports of assimp (done in https://github.com/conda-forge/assimp-feedstock/pull/74 and https://github.com/conda-forge/assimp-feedstock/pull/73)
* [ ] Relax the deps of all the packages built against assimp 6 (https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1195)
* [ ] Pin assimp to 6 in conda-forge-pinnings (this PR)

Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8172 .
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8454 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
