### PR TITLE
Add libplacebo and shaderc to global pinnings

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -656,6 +656,8 @@ libparu:
   - '1'
 libpcap:
   - '1.10'
+libplacebo:
+  - '7.351'
 libpnetcdf:
   - 1.14.1
 libpng:
@@ -996,6 +998,8 @@ sdl2_net:
   - '2'
 sdl2_ttf:
   - '2'
+shaderc:
+  - '2026.2'
 singular:
   - 4.4.1
 snappy:


### PR DESCRIPTION
Fix https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/8450 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
