### PR TITLE
Create combined migrator for azure storage release 2026-05

### DIFF
--- a/recipe/migrations/azure_storage_202605.yaml
+++ b/recipe/migrations/azure_storage_202605.yaml
@@ -1,0 +1,17 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure storage release 2026-05
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+azure_storage_common_cpp:
+- 12.13.0
+azure_storage_blobs_cpp:
+- 12.17.0
+azure_storage_files_datalake_cpp:
+- 12.15.0
+azure_storage_files_shares_cpp:
+- 12.17.0
+azure_storage_queues_cpp:
+- 12.7.0
+migrator_ts: 1778786092


### PR DESCRIPTION
Closes #8492
Closes #8493

cc: @teo-tsirpanis, @h-vetinari, @hmaarrfk, @conda-forge/azure-storage-common-cpp 
xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8484, https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8483

Back in January we decided to pursue a middle-ground strategy for migrating the various azure-cpp packages (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8132#issuecomment-3756589492): merge all passing feedstock PRs, and then start a combined migration

This PR updates the azure-storage-common-cpp only migration to a combined migration for the azure storage release from this month