### PR TITLE
Add osx_arm64 to astromatic tools.

### DIFF
--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -53,8 +53,12 @@ ast-grep
 ast-grep-py
 astra-toolbox
 astroid
+astromatic-psfex
 astromatic-scamp
+astromatic-skymaker
 astromatic-source-extractor
+astromatic-stiff
+astromatic-swarp
 astropy-healpix
 astroscrappy
 asv


### PR DESCRIPTION
Add osx_arm64 to astromatic as requested in conda-forge/astromatic-scamp-feedstock/issues/10