### PR TITLE
Drop dual HDF5 migration

### DIFF
--- a/recipe/migrations/hdf52.yaml
+++ b/recipe/migrations/hdf52.yaml
@@ -4,9 +4,10 @@ __migrator:
   kind: version
   migration_number: 1
 # HDF5 likely changed alot of its API
-# During the initial phase of the migration lets build for both
-# HDF5 2 and the latest version of HDF5
+# The initial transition phase built for both HDF5 2 and 1.14.6.
+# We now only migrate remaining feedstocks to HDF5 2.
+# Packages already built for HDF5 2 are unaffected (no build_number /
+# migration_number bump), so dropping 1.14.6 does not trigger rebuilds.
 hdf5:
 - '2'
-- '1.14.6'
 migrator_ts: 1774274234.55363


### PR DESCRIPTION
I feel like it has been long enough???

what do you all think?

cc: @conda-forge/hdf5 @h-vetinari 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
