### PR TITLE
add pytorch 2.11 migration

### DIFF
--- a/recipe/migrations/pytorch211.yaml
+++ b/recipe/migrations/pytorch211.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1780650079.6817513
+__migrator:
+  commit_message: Rebuild for pytorch 2.11
+  kind: version
+  migration_number: 1
+  bump_number: 1
+libtorch:
+- '2.11'
+pytorch:
+- '2.11'


### PR DESCRIPTION
We're unusually late with this, but https://github.com/conda-forge/pytorch-cpu-feedstock/pull/490 was very tricky, unfortunately. The already-release 2.12 doesn't look [any easier](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/503) either, so let's start migrating for 2.11 for the time being.

CC @conda-forge/pytorch-cpu