### PR TITLE
Add xrootd 6 migration (xrootd -> libxrootd-devel)

### DIFF
--- a/recipe/migrations/xrootd6.yaml
+++ b/recipe/migrations/xrootd6.yaml
@@ -1,0 +1,16 @@
+migrator_ts: 1780658331
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  # PRs are issued manually so the xrootd -> libxrootd-devel rename and any
+  # python-xrootd / xrootd-cli additions can be handled per feedstock
+  paused: true
+  commit_message: "Rebuild for xrootd 6 (xrootd -> libxrootd-devel)"
+# Old pin key: lists current xrootd dependents on the status page and rebuilds
+# any straggler against v6 even before the rename.
+xrootd:
+  - "6"
+# New pin key picked up once recipes are renamed to libxrootd-devel.
+libxrootd_devel:
+  - "6"


### PR DESCRIPTION
XRootD 6 splits the previously monolithic `xrootd` package into `libxrootd`, `libxrootd-devel`, `xrootd-cli` and `python-xrootd` outputs (plus an `xrootd` metapackage for compatibility). Downstream feedstocks should switch their host dependency from `xrootd` to `libxrootd-devel`, adding `python-xrootd`/`xrootd-cli` only where actually needed.

Since only a handful of feedstocks are affected, this migration is added with `paused: true` and the feedstock PRs will be issued manually (copying the migration into `.ci_support/migrations/`, renaming the dependency, and rerendering). The migration carries both the old `xrootd` pin key (for status tracking) and the new `libxrootd_devel` key.

When I close out the migrator I'll remove the `xrootd` key.