### PR TITLE
Update pins for azure storage release 2026-06

### DIFF
--- a/recipe/migrations/azure_storage_202606.yaml
+++ b/recipe/migrations/azure_storage_202606.yaml
@@ -1,0 +1,17 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure storage release 2026-06
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+azure_core_cpp:
+- 1.16.3
+azure_storage_common_cpp:
+- 12.14.0
+azure_storage_blobs_cpp:
+- 12.18.0
+azure_storage_files_datalake_cpp:
+- 12.16.0
+azure_storage_files_shares_cpp:
+- 12.18.0
+migrator_ts: 1781117529


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8398
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8600
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8602
Closes https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8603
Closes #8607
(there will be more as the bot opens them)

Combined migrator for latest azure storage release in June as well as azure-core-cpp update from April

cc: @h-vetinari 
xref: https://github.com/conda-forge/azure-core-cpp-feedstock/pull/35, https://github.com/conda-forge/azure-storage-files-datalake-cpp-feedstock/pull/31, https://github.com/conda-forge/azure-storage-common-cpp-feedstock/pull/31, https://github.com/conda-forge/azure-storage-files-shares-cpp-feedstock/pull/30, https://github.com/conda-forge/azure-storage-blobs-cpp-feedstock/pull/32