### PR TITLE
update abseil/grpc/protobuf 26q2 migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto_26Q2.yaml
+++ b/recipe/migrations/absl_grpc_proto_26Q2.yaml
@@ -19,9 +19,9 @@ __migrator:
     # built manually beforehand due to enormous build time
     - pytorch-cpu
 libabseil:
-- 20260107
+- 20260526
 libgrpc:
-- "1.80"
+- "1.82"
 libprotobuf:
-- 7.34.1
+- 7.35.1
 migrator_ts: 1775539322.336586


### PR DESCRIPTION
Need newest grpc to be compatible with newer protobuf; pick up new abseil release. This migration hasn't started yet, so we can freely adapt things.