### PR TITLE
add migration for pytorch 2.12

### DIFF
--- a/recipe/migrations/pytorch212.yaml
+++ b/recipe/migrations/pytorch212.yaml
@@ -1,0 +1,10 @@
+migrator_ts: 1781488253.473079
+__migrator:
+  commit_message: Rebuild for pytorch 2.12
+  kind: version
+  migration_number: 1
+  bump_number: 1
+libtorch:
+- '2.12'
+pytorch:
+- '2.12'


### PR DESCRIPTION
The [migration](https://conda-forge.org/status/migration/?name=pytorch211) for the much-delayed(-in-conda-forge) pytorch 2.11 is not closeable yet, but already more than 50% done. With 2.12, we had much less of a delay compared to the upstream release, so now back to regular scheduled programming.

