### PR TITLE
Migrate for aws-c-* mid-june'26

### DIFF
--- a/recipe/migrations/aws_c_midjune26.yaml
+++ b/recipe/migrations/aws_c_midjune26.yaml
@@ -1,0 +1,18 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (mid-june'26)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1781535050
+aws_c_mqtt:
+  - '0.16.0'
+aws_c_s3:
+  - '0.12.6'
+aws_c_sdkutils:
+  - '0.2.5'
+aws_crt_cpp:
+  - '0.40.1'
+s2n:
+  - '1.7.4'


### PR DESCRIPTION
aws-c-* migration for mid-june'26

## Updated packages:
- aws_c_mqtt: 0.16.0
- aws_c_s3: 0.12.6
- aws_c_sdkutils: 0.2.5
- aws_crt_cpp: 0.40.1
- s2n: 1.7.4
