### PR TITLE
start 26Q2 abseil/grpc/protobuf migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto_26Q2.yaml
+++ b/recipe/migrations/absl_grpc_proto_26Q2.yaml
@@ -1,9 +1,13 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for libabseil 20260526, libgrpc 1.82 & libprotobuf 7.35.1
+  commit_message: |
+    Rebuild for libabseil 20260526, libgrpc 1.82 & libprotobuf 7.35.1
+    
+    grpc v1.82 is currently in pre-release and thus not published yet.
+    Therefore, it is expected that feedstocks depending on libgrpc will
+    see resolver errors for now.
   kind: version
   migration_number: 1
-  paused: true
   exclude:
     # core deps
     - abseil-cpp


### PR DESCRIPTION
This took a while because grpc needed to become compatible with protobuf >=v34, which happened as of grpc v1.82 that's currently in pre-release, but builds fine on the feedstock. I'd like to start this migration anyway, to start chewing through all the feedstocks that only depend on abseil and/or protobuf already.

* https://github.com/conda-forge/abseil-cpp-feedstock/pull/109
* https://github.com/conda-forge/grpc-cpp-feedstock/pull/430
* https://github.com/conda-forge/libprotobuf-feedstock/pull/297
* https://github.com/conda-forge/libprotobuf-feedstock/pull/298
* https://github.com/conda-forge/libprotobuf-feedstock/pull/299
* https://github.com/conda-forge/protobuf-feedstock/pull/276
* https://github.com/conda-forge/protobuf-feedstock/pull/277
* https://github.com/conda-forge/re2-feedstock/pull/102
* https://github.com/conda-forge/pytorch-cpu-feedstock/pull/523
* https://github.com/conda-forge/pytorch-cpu-feedstock/pull/522

CC @conda-forge/abseil-cpp @conda-forge/grpc-cpp @conda-forge/libprotobuf @conda-forge/protobuf

Closes #8290 
Closes #8363 
Closes #8429 
Closes #8523 
Closes #8612 
Closes #8405 
Closes #8563 
Closes #8568 