### PR TITLE
Add bioimage-cpp and z5py to linux-arch migration

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -52,6 +52,7 @@ bilby.cython
 binaryen
 bindensity
 binsider
+bioimage-cpp
 biom-format
 bipedal-locomotion-framework
 bitshuffle
@@ -1392,6 +1393,7 @@ yappi
 yarp
 yoda
 yt
+z5py
 zaber-motion
 zchunk
 zenoh-cpp


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hi @conda-forge/core,
this PR adds to packages I am mainting, [bioimage-cpp](https://github.com/conda-forge/bioimage-cpp-feedstock) and [z5py](https://github.com/conda-forge/z5py-feedstock), to the linux-arm migration. Both packages have few dependencies that should already be migrated. I followed the steps from https://conda-forge.org/docs/how-to/advanced/enable-archs/#automated-migrations for the migration.

Note: the PR template contains the typical steps for a feedstock PR. Is this relevant here?
