### PR TITLE
Migrate for aws-c-* end-of-june'26

### DIFF
--- a/recipe/migrations/aws_c_endofjune26.yaml
+++ b/recipe/migrations/aws_c_endofjune26.yaml
@@ -1,0 +1,14 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (end-of-june'26)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1782725280
+aws_c_common:
+  - '0.14.1'
+aws_c_sdkutils:
+  - '0.2.6'
+s2n:
+  - '1.7.5'


### PR DESCRIPTION
aws-c-* migration for end-of-june'26

## Updated packages:
- aws_c_common: 0.14.1
- aws_c_sdkutils: 0.2.6
- s2n: 1.7.5
