### PR TITLE
Rebuild for gpgme 1.24

### DIFF
--- a/recipe/migrations/gpgme124.yaml
+++ b/recipe/migrations/gpgme124.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for gpgme 1.24
+  kind: version
+  migration_number: 1
+migrator_ts: 1782806384
+gpgme:
+- '1.24'


### PR DESCRIPTION
Adds a migration to rebuild gpgme dependents for **gpgme 1.24**.

## Context

The `gpgme` feedstock was recently updated from 1.18.0 → 1.24.3 (and migrated to the v1 recipe format). gpgme uses `run_exports` with an `x.x` pin and is **not** in the global pinning, so its dependents are held to whatever minor they were last built against.

All current dependents are frozen on **gpgme 1.17/1.18** (the feedstock sat at 1.18 for ~3 years):

| Feedstock | Current pin |
|---|---|
| podman | `>=1.18.0,<1.19` |
| buildah | `>=1.18.0,<1.19` |
| librepo | `>=1.17.1,<1.18` |
| r-gpg | `>=1.18.0,<1.19` |
| gpg-tui | `>=1.18.0,<1.19` |

This migration brings them up to the current 1.x (1.24.3). It is intentionally staged ahead of the gpgme **2.x** ABI bump (soname 11 → 45): modernizing dependents onto a known-good 1.x first de-risks the subsequent major-version migration, which will be submitted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)