### PR TITLE
Add ARM builds from gmime and mu

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -280,6 +280,7 @@ git-cliff
 glimpse
 glm
 glum
+gmime
 gmsh
 gmt
 gnss-sdr
@@ -525,6 +526,7 @@ mrchem
 mrcpp
 msgspec
 msprime
+mu
 mujoco
 muspinsim
 myproxy

--- a/recipe/migration_support/osx_arm64.txt
+++ b/recipe/migration_support/osx_arm64.txt
@@ -501,6 +501,7 @@ gmatelastoplastic
 gmatelastoplasticfinitestrainsimo
 gmatnonlinearelastic
 gmattensor
+gmime
 gmp
 gmsh
 gmso
@@ -881,6 +882,7 @@ msgpack-cxx
 msgspec
 msitools
 msvc-headers-libs
+mu
 mujoco
 multicore-tsne
 multimark


### PR DESCRIPTION
Add ARM (and possibly ppc64le) builds from the fresh [gmime](https://github.com/conda-forge/gmime-feedstock) and [mu](https://github.com/conda-forge/mu-feedstock) packages on osx and windows.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
