### PR TITLE
Add global pin and migration for libjxl

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -473,6 +473,8 @@ lhapdf:
   - '6.5'
 libjpeg_turbo:
   - '3'
+libjxl:
+  - '0.11'
 libev:
   - 4.33
 json_c:

--- a/recipe/migrations/libjxl012.yaml
+++ b/recipe/migrations/libjxl012.yaml
@@ -1,0 +1,8 @@
+migrator_ts: 1783088333
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+
+libjxl:
+  - '0.12'


### PR DESCRIPTION
See https://github.com/conda-forge/libjxl-split-feedstock/issues/52

I'm going to merge this to start rebuilding a few key packages (ffmpeg, opencv) basically none will work since they all depend on libjxl.

I'll eventually just cleanup the old packages when the maintainer responds.

We can always "remove this", but getting this through will take time.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
