### PR TITLE
remove grpc caveat for abseil migration

### DIFF
--- a/recipe/migrations/absl_grpc_proto_26Q2.yaml
+++ b/recipe/migrations/absl_grpc_proto_26Q2.yaml
@@ -1,11 +1,6 @@
 __migrator:
   build_number: 1
-  commit_message: |
-    Rebuild for libabseil 20260526, libgrpc 1.82 & libprotobuf 7.35.1
-    
-    grpc v1.82 is currently in pre-release and thus not published yet.
-    Therefore, it is expected that feedstocks depending on libgrpc will
-    see resolver errors for now.
+  commit_message: Rebuild for libabseil 20260526, libgrpc 1.82 & libprotobuf 7.35.1
   kind: version
   migration_number: 1
   exclude:


### PR DESCRIPTION
Now that https://github.com/conda-forge/grpc-cpp-feedstock/pull/430 has been merged