### PR TITLE
MNT: Relax fastjet-contrib pinning to SemVer major level

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -351,7 +351,7 @@ expat:
 fastbdt:
   - '5.6'
 fastjet_contrib:
-  - '1.103'
+  - '1'
 fastjet_cxx:
   - '3.5'
 feynhiggs:


### PR DESCRIPTION
* Relax the pinning for `fastjet-contrib` given decisions made in https://github.com/conda-forge/fastjet-contrib-feedstock/issues/21#issuecomment-4706457444 and https://github.com/conda-forge/fastjet-contrib-feedstock/pull/22.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [N/A] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [N/A] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
