### PR TITLE
Migrate for aws-c-* mid-july'26

### DIFF
--- a/recipe/migrations/aws_c_midjuly26.yaml
+++ b/recipe/migrations/aws_c_midjuly26.yaml
@@ -1,0 +1,16 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (mid-july'26)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1784027017
+aws_c_auth:
+  - '0.10.4'
+aws_c_common:
+  - '0.14.2'
+aws_c_io:
+  - '0.27.3'
+aws_c_s3:
+  - '0.12.8'


### PR DESCRIPTION
aws-c-* migration for mid-july'26

## Updated packages:
- aws_c_auth: 0.10.4
- aws_c_common: 0.14.2
- aws_c_io: 0.27.3
- aws_c_s3: 0.12.8
