### PR TITLE
Add libdovi to global pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -555,6 +555,8 @@ libdap4:
   - 3.20.6
 libdeflate:
   - '1.25'
+libdovi:
+  - 3.3.2
 libduckdb_devel:
   - '1'
 libeantic:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -556,7 +556,7 @@ libdap4:
 libdeflate:
   - '1.25'
 libdovi:
-  - 3.3.2
+  - '3'
 libduckdb_devel:
   - '1'
 libeantic:


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/8724 :

Pin libdovi at the current 3.3.2 release since libdovi has a run export and is inside the dependency chain: libdovi > libplacebo > ffmpeg

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
