### PR TITLE
Update libffi global pin to 3.7

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -564,7 +564,7 @@ libevent:
 libexactreal:
   - '4'
 libffi:
-  - '3.5'
+  - '3.7'
 libflac:
   - '1.5'
 libflatsurf:

--- a/recipe/migrations/libffi37.yaml
+++ b/recipe/migrations/libffi37.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libffi 3.7
+  kind: version
+  migration_number: 1
+libffi:
+- '3.7'
+migrator_ts: 1784193995


### PR DESCRIPTION
## Summary

- Update the global libffi pin from 3.5 to 3.7.
- Add the corresponding CFEP-09 version migration so dependent feedstocks are rebuilt.

## Validation

- conda-smithy rerender: no changes made.
- conda-smithy recipe-lint recipe: passed.
- Targeted pre-commit checks for the new migration YAML: passed.
- Migration tests excluding the existing local-only timestamp harness path: 98 passed.

No generated CI files or unrelated recipe changes are included.