### PR TITLE
Fix migration test set insertion

### DIFF
--- a/recipe/test_migrations.py
+++ b/recipe/test_migrations.py
@@ -84,7 +84,7 @@ def test_timestamps_against_main():
             new_files = set()
             for filename in all_migrations:
                 if os.path.basename(filename) not in current_migrations:
-                    new_files.aadd(filename)
+                    new_files.add(filename)
         else:
             # use main from feedstock checkout in the build
             # so diff of files is accurate even if upstream main is not


### PR DESCRIPTION
## Summary

- Fix a typo in the local fallback path of `test_timestamps_against_main`.
- Use the set's `add` method so direct local migration tests can collect new files.

## Validation

- `pytest -vvs recipe/test_migrations.py`: 96 passed.
- `conda-smithy recipe-lint recipe`: passed.
- Targeted pre-commit checks: passed.
- `git diff --check`: passed.

This is a separate test-only contribution with no recipe, migration, or generated CI changes.