### PR TITLE
add OIIO and OCIO library pins

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -677,6 +677,10 @@ libode:
   - 0.16.6
 libogg:
   - 1.3
+libopencolorio:
+  - '2.5'
+libopenimageio:
+  - '3.1'
 libopencv:
   - 4.13.0
 libopentelemetry_cpp:


### PR DESCRIPTION
Following recent refactor and [upgrade to 3.X](https://github.com/conda-forge/openimageio-feedstock/pull/138) of OIIO (openimageio) and addition of the OCIO (opencolorio) builds and split into multiple packages:

- libopencolorio: OCIO core library and headers
- py-opencolorio: OCIO Python bindings
- libopenimageio: OIIO core library and headers
- py-openimageio: OIIO Python bindings
- openimageio-tools: OIIO command-line tools
- opencolorio-tools: OCIO command-line tools (built with OIIO lib support)
- openimageio: metapackage OIIO library and command-line tools bundle
- opencolorio: metapackage OCIO library and command-line tools bundle

Thus with explicit library packages (libopenimageio & libopencolorio), it seems relevant and necessary to add them to the global pinning.

Hence this PR pins libopenimageio to 3.1 and libopencolorio to 2.5, matching their minor-level run exports for ABI migrations.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
