### PR TITLE
Close qt6.11 migration and loosen qt6 pin

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1009,7 +1009,7 @@ qt:
 qt_main:
   - 5.15
 qt6_main:
-  - '6.10'
+  - '6'
 qtkeychain:
   - '0.16'
 rav1e:

--- a/recipe/migrations/qt6_main611.yaml
+++ b/recipe/migrations/qt6_main611.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for qt6_main 6.11
-  kind: version
-  migration_number: 1
-migrator_ts: 1774298951.6675055
-qt6_main:
-- '6.11'


### PR DESCRIPTION
A few PRs are still there:
- https://github.com/conda-forge/qt6-advanced-docking-system-feedstock/pull/27
- https://github.com/conda-forge/codes-ui-feedstock/pull/23
- https://github.com/conda-forge/nionswift-tool-feedstock/pull/38
- https://github.com/conda-forge/nionui-tool-feedstock/pull/63
- https://github.com/conda-forge/qcachegrind-feedstock/pull/9
- https://github.com/conda-forge/qt6-keychain-feedstock/pull/1
- https://github.com/conda-forge/qtmolecularnetwork-feedstock/pull/30
- https://github.com/conda-forge/veusz-feedstock/pull/42

But they have been pretty untouched

xref: https://github.com/conda-forge/qt-main-feedstock/pull/405

https://github.com/conda-forge/qt-main-feedstock/blob/6d4c63e6d236b14d33da54d296d7d999b7560476/recipe/recipe.yaml#L183

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
