### PR TITLE
Add osqp and qdldl-python to free-threading (3.14t) allowlist

### DIFF
--- a/recipe/migration_support/free-threaded-314.txt
+++ b/recipe/migration_support/free-threaded-314.txt
@@ -186,6 +186,7 @@ openstep-plist
 optree
 orange3-associate
 ormsgpack
+osqp
 p4p
 panda3d
 pandas
@@ -290,6 +291,7 @@ pywavelets
 pywinpty
 pyyaml
 pyzmq
+qdldl-python
 qh3
 quaternion
 randomgen


### PR DESCRIPTION
osqp and qdldl-python now publish cp314t wheels on PyPI (osqp 1.1.3, qdldl 0.1.9.post1) but postdate the last simple-index-db refresh (2026-01-11), so adding them manually per the wheel criterion.

Motivation is conda-forge/cvxpy-feedstock#124:

> would it be possible to provide a build compatible with python free threaded (*_cp314t) ?

The rest of that stack (clarabel, highspy) has no cp314t wheels upstream yet, so not included here.
