### PR TITLE
Pin libtheora to 1.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -757,6 +757,8 @@ libtensorflow:
   - "2.16"
 libtensorflow_cc:
   - "2.16"
+libtheora:
+  - "1.1"
 libthrift:
   - 0.22.0
 libtiff:


### PR DESCRIPTION
libtheora contains a run_exports, but it was never pinned.  Let's pinned it know, so that we can then merge https://github.com/conda-forge/libtheora-feedstock/pull/25 and do a proper migration.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
