### PR TITLE
NEW: Migrate to dav1d>=1.3.0

### DIFF
--- a/recipe/migrations/dav1d130.yaml
+++ b/recipe/migrations/dav1d130.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for dav1d 1.3.0 and rename dav1d to dav1d-dev
+  kind: version
+  migration_number: 1
+dav1d:
+- '1.3.0'
+migrator_ts: 1784845364

--- a/recipe/migrations/dav1d130.yaml
+++ b/recipe/migrations/dav1d130.yaml
@@ -1,8 +1,8 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for dav1d 1.3.0 and rename dav1d to dav1d-devel
+  commit_message: Rebuild for dav1d 1.5.4 and rename dav1d to dav1d-devel
   kind: version
   migration_number: 1
 dav1d:
-- '1.3.0'
+- '1.5.4'
 migrator_ts: 1784845364

--- a/recipe/migrations/dav1d130.yaml
+++ b/recipe/migrations/dav1d130.yaml
@@ -1,6 +1,6 @@
 __migrator:
   build_number: 1
-  commit_message: Rebuild for dav1d 1.3.0 and rename dav1d to dav1d-dev
+  commit_message: Rebuild for dav1d 1.3.0 and rename dav1d to dav1d-devel
   kind: version
   migration_number: 1
 dav1d:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Create a mini-migrator which will migrate `dav1d` to `dav1d-devel`. Starting with `dav1d=1.3.0`, the `dav1d` package was split into runtime and development components and allowed looser run_exports. Starting with `dav1d=1.5.4`, the development package uses `-devel` instead of `-dev`. The current channel pinnings are `dav1d=1.2.1`. The latest `dav1d` version is `1.5.4`.

Depends on https://github.com/conda-forge/conda-forge-bot/pull/6356

cc: @conda-forge/dav1d