### PR TITLE
add libraqm to pinning and migrate for new version

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -709,6 +709,8 @@ libpsl:
   - '0.22'
 libpulsar:
   - 4.2.0
+libraqm:
+  - '0.10'
 libraw:
   - '0.22'
 librbio:

--- a/recipe/migrations/libraqm011.yaml
+++ b/recipe/migrations/libraqm011.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libraqm 0.11
+  kind: version
+  migration_number: 1
+libraqm:
+- '0.11'
+migrator_ts: 1784850426.0659938


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/libraqm-feedstock/pull/5, now that we're moving out of the 0.10.x territory