### PR TITLE
Ignore metadata comment in free-threaded-314.txt from sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,10 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
-    - id: file-contents-sorter
+    # we use this instead of file-content-sorter, because it will correctly
+    # ignore metadata comments like we have in free-threaded-314.txt; see
+    # https://github.com/pre-commit/pre-commit-hooks/issues/1266
+    - id: requirements-txt-fixer
       files: recipe/migration_support/.*\.txt
     - id: check-toml
       files: recipe\/.*\.toml

--- a/recipe/migration_support/free-threaded-314.txt
+++ b/recipe/migration_support/free-threaded-314.txt
@@ -1,11 +1,11 @@
+# This file was created with simple-index-db 0.2.0.
 # It is based on data from PyPI's simple index as follows:
+# ts: 1784830666
+# date: 2026-07-23 18:17:46
 # Last serial of package listing: 39304776
 # Last serial of received package data: 39305440
-# Number of selected conda-forge packages: 571
-# This file was created with simple-index-db 0.2.0.
 # Total number of projects on PyPI: 856119
-# date: 2026-07-23 18:17:46
-# ts: 1784830666
+# Number of selected conda-forge packages: 571
 abess
 adani
 adbc-driver-manager


### PR DESCRIPTION
The metadata comment generated by `simple-index-db` (c.f. #8763) fails our linter, which insists on sorting lines even though they start with a comment; obviously this messes up the semantic meaning of the comment.

I asked for a work-around for this in https://github.com/pre-commit/pre-commit-hooks/issues/1266, which was insta-closed and locked as a duplicate of https://github.com/pre-commit/pre-commit-hooks/issues/647; after inquiring privately, the response I got was "requirements-txt-fixer does what you want". So let's use that, even though the name suggest a tighter scope than what we need.