### PR TITLE
redo libraqm migration with devel package

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -712,7 +712,9 @@ libpsl:
 libpulsar:
   - 4.2.0
 libraqm:
-  - '0.11'
+  - '0.10'
+libraqm_devel:
+  - '0.10'
 libraw:
   - '0.22'
 librbio:

--- a/recipe/migration_support/packages_to_migrate_together.yaml
+++ b/recipe/migration_support/packages_to_migrate_together.yaml
@@ -70,6 +70,10 @@ libpq:
   - postgresql
   - postgresql_plpython
 
+libraqm:
+  - libraqm
+  - libraqm_devel
+
 libscotch:
   - libscotch
   - libptscotch

--- a/recipe/migrations/libraqm011.yaml
+++ b/recipe/migrations/libraqm011.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libraqm 0.11
+  kind: version
+  migration_number: 2
+libraqm:
+- '0.11'
+libraqm_devel:
+- '0.11'
+migrator_ts: 1785112427.238149


### PR DESCRIPTION
Turns out https://conda-forge.org/status/migration/?name=libraqm011 didn't apply to any feedstocks; probably because users like https://github.com/conda-forge/matplotlib-feedstock/pull/441 are using `libraqm-devel`