### PR TITLE
Migrate for aws-c-* end-of-july'27

### DIFF
--- a/recipe/migrations/aws_c_endofjuly27.yaml
+++ b/recipe/migrations/aws_c_endofjuly27.yaml
@@ -1,0 +1,18 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (end-of-july'27)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1785142307
+aws_c_cal:
+  - '0.9.15'
+aws_c_common:
+  - '0.14.3'
+aws_c_io:
+  - '0.27.5'
+aws_c_s3:
+  - '0.13.1'
+aws_crt_cpp:
+  - '0.42.3'


### PR DESCRIPTION
aws-c-* migration for end-of-july'27

## Updated packages:
- aws_c_cal: 0.9.15
- aws_c_common: 0.14.3
- aws_c_io: 0.27.5
- aws_c_s3: 0.13.1
- aws_crt_cpp: 0.42.3
