### PR TITLE
GCC v15 & Clang v21

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,9 +4,8 @@ c_compiler:
   - vs2022                     # [win]
 # Please remember to update gcc_compiler_version & clang_compiler_version too.
 c_compiler_version:            # [unix]
-  - 14                         # [linux and not riscv64]
-  - 15                         # [linux and riscv64]
-  - 19                         # [osx]
+  - 15                         # [linux]
+  - 21                         # [osx]
   - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 c_stdlib:
   - sysroot                    # [linux]
@@ -27,57 +26,52 @@ cxx_compiler:
   - vs2022                     # [win]
 # Please remember to update gxx_compiler_version & clangxx_compiler_version too.
 cxx_compiler_version:          # [unix]
-  - 14                         # [linux and not riscv64]
-  - 15                         # [linux and riscv64]
-  - 19                         # [osx]
+  - 15                         # [linux]
+  - 21                         # [osx]
   - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 llvm_openmp:                   # [osx]
-  - 19                         # [osx]
+  - 21                         # [osx]
 fortran_compiler:              # [unix or win64]
   - gfortran                   # [unix]
   - flang                      # [win64]
 fortran_compiler_version:      # [unix or win64]
-  - 14                         # [linux and not riscv64]
-  - 15                         # [linux and riscv64]
-  - 14                         # [osx]
+  - 15                         # [unix]
   - 5                          # [win64]
   - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 m2w64_c_compiler:                 # [win]
   - gcc                           # [win]
 m2w64_c_compiler_version:         # [win]
-  - 14                            # [win]
+  - 15                            # [win]
 m2w64_cxx_compiler:               # [win]
   - gxx                           # [win]
 m2w64_cxx_compiler_version:       # [win]
-  - 14                            # [win]
+  - 15                            # [win]
 m2w64_fortran_compiler:           # [win]
   - gfortran                      # [win]
 m2w64_fortran_compiler_version:   # [win]
-  - 14                            # [win]
+  - 15                            # [win]
 
 # enable `{{ compiler("gcc") }}`, `{{ compiler("clang") }}` & co.
 gcc_compiler:
   - gcc
 gcc_compiler_version:
-  - 14  # [not osx]
-  - 15  # [osx]
+  - 15
 gxx_compiler:
   - gxx
 gxx_compiler_version:
-  - 14  # [not osx]
-  - 15  # [osx]
+  - 15
 clang_compiler:
   - clang     # [unix]
   # stay compatible with MSVC
   - clang-cl  # [win]
 clang_compiler_version:
-  - 19
+  - 21
 clangxx_compiler:
   - clangxx   # [unix]
   # stay compatible with MSVC
   - clang-cl  # [win]
 clangxx_compiler_version:
-  - 19
+  - 21
 
 cuda_compiler:
   - cuda-nvcc

--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -53,10 +53,10 @@ c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ
   - 2.28                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 15                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 cxx_compiler_version:          # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 15                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 fortran_compiler_version:      # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 15                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
GCC `{N-1}.3`[^1] was released in May, which is the annual trigger for the spring compiler update; it took until now to get the major pieces unblocked. Clang 21 has already long reached its conclusion (as did clang 22 actually), but our rhythm for clang so far has been odd versions in the spring and even version in the fall (c.f. links below). Note that we skipped clang 20 due to an ABI break that was only discovered towards the tail end of the life cycle, and undone in v21 again (c.f. #7839).

[^1]: where N is the most recent version, and .3 is comprehensive bugfix release for the previous major version that follows shortly afterwards.

Clang 21 & GCC 15 are also the first compiler versions where we default to "minimally activated compilers", details [here](https://github.com/conda-forge/conda-forge.github.io/issues/2595).

### To-Do list based on [docs](https://conda-forge.org/docs/maintainer/infrastructure/#more-on-compiler-feedstocks)

* [x] Update all respective feedstocks
  * [x] GCC 15
    * [x] https://github.com/conda-forge/ctng-compilers-feedstock/pull/211
    * [x] https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/200
    * [x] Other feedstocks are not necessary anymore, see https://github.com/conda-forge/conda-forge.github.io/pull/2905; still, I've opened:
      * https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/pull/95 
      * https://github.com/conda-forge/gfortran_osx-64-feedstock/pull/65
  * [x] Clang 21 (listing only activation PR; it wouldn't pass if the implementation wasn't complete)
    * [x] https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/181
  * [x] metapackages
    * [x] https://github.com/conda-forge/compilers-feedstock/pull/78
    * [x] https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/158 (clang-on-linux; not part of global pinning)
    * [x] https://github.com/conda-forge/clang-win-activation-feedstock/pull/54 (clang-on-win; not part of the global pinning)
    * [x] https://github.com/conda-forge/r_clang_activation-feedstock/pull/12 (clang for r-feedstocks; not part of global pinning)
* [x] Tested that compilers work
  * https://github.com/conda-forge/scipy-feedstock/pull/250 (includes fortran)
* [x] Checked nvcc-bounds (see docs for [CUDA 12.9](https://docs.nvidia.com/cuda/archive/12.9.2/cuda-installation-guide-linux/index.html#host-compiler-support-policy) & [CUDA 13.0](https://docs.nvidia.com/cuda/archive/13.0.3/cuda-installation-guide-linux/index.html#host-compiler-support-policy))
  * Cannot update for CUDA 12.9 because we're already at the limit there (GCC 14)
* [x] Checked release notes for ABI-relevant changes
  * [x] GCC [release notes](https://gcc.gnu.org/gcc-15/changes.html) & [porting guide](https://gcc.gnu.org/gcc-15/porting_to.html)
    * GCC 15 now defaults to the C23 standard, which is somewhat stricter than C17. A lot of relevant warnings were already emitted with GCC 13 & 14.
  * [x] Clang v20 [potentially breaking changes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes)
    * Minor changes for overflow handling
  * [x] Clang v21 [potentially breaking changes](https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes)
    * Nothing that stands out
  * [x] Clang & libcxx v20 [ABI changes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version)
    * https://github.com/llvm/llvm-project/issues/154985:
      This was the reason we didn't use clang 20 as a default; clang went back to the v19 behaviour as of v21.
  * [x] Clang & libcxx v21 [ABI changes](https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version)
    * Large records may be returned in memory rather than (where available) AVX registers. Since we're defaulting to an old instruction set baseline, this should not affect us.
    * Also compare changes in [19](https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [18](https://releases.llvm.org/18.1.8/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [17](https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [16](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-this-version), [15](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-clang) & [14](https://releases.llvm.org/14.0.0/tools/clang/docs/ReleaseNotes.html#abi-changes-in-clang)
* [x] https://github.com/conda-forge/conda-forge.github.io/pull/2906


Previously: #7839 #7421 #6571 #4890 #4991 #4215 #3731 #3290 #3261 #2802 #2010 

CC @conda-forge/core