### PR TITLE
Ignore pyside6 for 3.14t migration

### DIFF
--- a/recipe/migrations/python314t.yaml
+++ b/recipe/migrations/python314t.yaml
@@ -34,6 +34,7 @@ __migrator:
     ignored_deps_per_node:
         matplotlib:
             - pyqt
+            - pyside6
         pyarrow:
             # optional test dependencies
             - numba


### PR DESCRIPTION
matplotlib already has builds that skip pyside6 for 3.146, but the migrator is still waiting for pyside6

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
