### PR TITLE
Migrate for aws-c-* start-of-august'26

### DIFF
--- a/recipe/migrations/aws_c_startofaugust26.yaml
+++ b/recipe/migrations/aws_c_startofaugust26.yaml
@@ -1,0 +1,22 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for aws-c-* (start-of-august'26)
+  kind: version
+  migration_number: 1
+  exclude_pinned_pkgs: false
+  automerge: true
+migrator_ts: 1785855565
+aws_c_cal:
+  - '0.9.15'
+aws_c_common:
+  - '0.14.4'
+aws_c_io:
+  - '0.27.5'
+aws_c_mqtt:
+  - '0.16.1'
+aws_c_s3:
+  - '0.13.1'
+aws_c_sdkutils:
+  - '0.2.8'
+aws_crt_cpp:
+  - '0.43.0'


### PR DESCRIPTION
aws-c-* migration for start-of-august'26

## Updated packages:
- aws_c_cal: 0.9.15
- aws_c_common: 0.14.4
- aws_c_io: 0.27.5
- aws_c_mqtt: 0.16.1
- aws_c_s3: 0.13.1
- aws_c_sdkutils: 0.2.8
- aws_crt_cpp: 0.43.0
