### PR TITLE
Revert "skip special migrations in test_timestamps_against_main"

### DIFF
--- a/recipe/test_migrations.py
+++ b/recipe/test_migrations.py
@@ -128,9 +128,6 @@ def test_timestamps_against_main():
                     )
 
         for filename in new_files:
-            if filename.endswith(".txt"):
-                # skip filter lists for special migrations
-                continue
             with open(filename, "r", encoding="utf-8") as f:
                 data = yaml.load(f, Loader=yaml.SafeLoader)
                 print(


### PR DESCRIPTION
For https://github.com/conda-forge/conda-forge-bot/pull/6417, as diagnosed by @beckermr. I remember adding this after debugging some issue in #7777, but since this change ultimately got broken out into another PR (#7900), I can't really reconstruct what that was. I guess we'll see here in CI