### PR TITLE
Start libattr 2.6 migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -511,7 +511,7 @@ libarrow_all:
   - '23.0'
   - '22.0'
 libattr:
-  - 2.5
+  - 2.6
 libavif:
   - 1
 libblitz:

--- a/recipe/migrations/libattr26.yaml
+++ b/recipe/migrations/libattr26.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libattr 2.6
+  kind: version
+  migration_number: 1
+libattr:
+- 2.6
+migrator_ts: 1785998598


### PR DESCRIPTION
Update the global `libattr` pin from 2.5 to 2.6 and add the corresponding version migration.

`libattr 2.6.0` is available on all supported Linux platforms, including linux-riscv64. This fixes the RISC-V dependency gap without bypassing the global pin in downstream recipes.

Validation:
- conda-smithy lint
- pre-commit on both changed YAML files
- migration tests: 96 passed
- conda-smithy rerender: generated only unrelated tooling updates, omitted from this PR

Related: conda-forge/libacl-feedstock#8
