### PR TITLE
Fix libnetcdf pin back to 4.10.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -672,7 +672,7 @@ libmatio_cpp:
 libmicrohttpd:
   - '1.0'
 libnetcdf:
-  - 4.10.0
+  - 4.10.1
 libntlm:
   - 1
 libode:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
*  Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
*  [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
*  Ensured the license file is being packaged.

PR #8753 mistakenly downgraded the libnetcdf pin to `4.10.0`,  it should be `4.10.1` with d4bc25491d733