### PR TITLE
Add CMake to linux-riscv64 migration targets

### DIFF
--- a/recipe/migration_support/linux_riscv64.txt
+++ b/recipe/migration_support/linux_riscv64.txt
@@ -1,6 +1,7 @@
 anaconda-client
 clang
 clangxx
+cmake
 compiler-rt
 conda
 conda-build


### PR DESCRIPTION
## Summary

- add `cmake` to the explicit linux-riscv64 migration targets

## Why

conda-forge/libsodium-feedstock#31 currently fails only for `linux_riscv64` because its package test requires CMake, but no `linux-riscv64` CMake package is available.

The architecture migrator builds its graph from host and run requirements. Since CMake is only a test requirement of libsodium, it is not discovered as a predecessor. Making CMake an explicit target lets the migrator schedule `cmake-feedstock` and its host/run dependency chain.

## Validation

- `git diff --check`
- `LC_ALL=C sort -c recipe/migration_support/linux_riscv64.txt`
