### PR TITLE
add AI to linux-riscv64 targets

### DIFF
--- a/recipe/migration_support/linux_riscv64.txt
+++ b/recipe/migration_support/linux_riscv64.txt
@@ -8,8 +8,14 @@ conda-build
 conda-forge-ci-setup
 conda-libmamba-solver
 git
+llama-cpp-python
+llama.cpp
 mamba
 micromamba
+onednn
+onnx
+onnxruntime
+opencv
 patch
 pip
 pixi
@@ -17,3 +23,4 @@ python
 rattler-build
 su-exec
 tini
+vllm


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Hello Conda team,

As the maintainer of RISC-V AI software in the openKylin community (together with @bitsk), I've submitted RISC-V support PRs to each of these upstream projects and would like to enable them for RISC-V in conda-forge.

<!--
Please add any other relevant info below:
-->
