### PR TITLE
close pybind11_abi migration

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -970,7 +970,7 @@ pulseaudio_client:
 pulseaudio_daemon:
   - '17.0'
 pybind11_abi:
-  - 4
+  - 11
 pythia8:
   - '8.312'
 python:

--- a/recipe/migrations/pybind11_abi11.yaml
+++ b/recipe/migrations/pybind11_abi11.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for pybind11 3 and pybind11_abi 11
-  kind: version
-  migration_number: 1
-migrator_ts: 1752454025.946169
-pybind11_abi:
-- '11'


### PR DESCRIPTION
This migration has been open for over a year, and not much of anything is happening anymore. Also, there's the next migration waiting in the wings already (#8838). So I suggest to just close this one.

CC @conda-forge/pybind11 