### PR TITLE
remove wait_for_migrators for closed migration

### DIFF
--- a/recipe/migrations/cuda130.yaml
+++ b/recipe/migrations/cuda130.yaml
@@ -22,8 +22,6 @@ __migrator:
       # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7472
       # must be last due to how cuda_compiler ordering in that migrator works
       - 11.8
-  wait_for_migrators:
-    - cuda129
   commit_message: |
     Upgrade to CUDA 13.0
     


### PR DESCRIPTION
Noticed this today in the migrator logs
```
MigrationYaml-cuda130 IS MIGRATING finufft-split
  2026-08-13 08:20:52,090 DEBUG    conda_forge_tick.migrators.migration_yaml || filter finufft-split: need to wait for ['cuda129']
```

That migration was closed long ago (#8152), so waiting for it makes no sense.