### PR TITLE
Add cran_mirror default variant

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -314,6 +314,8 @@ collier:
   - '1.2'
 console_bridge:
   - 1.0
+cran_mirror:
+  - 'https://cloud.r-project.org'
 # match with libcudnn-dev
 cudnn:
   - '9'


### PR DESCRIPTION
* Add a default variant for 'cran_mirror' so that all recipe builds will be able to use this variable. For the mirror use https://cloud.r-project.org/, a cloud mirror of CRAN that auto-redirects to the optimal server based on "user" location, over the "default" of https://cran.r-project.org/.
   - c.f. https://github.com/conda-forge/r-tinkr-feedstock/pull/9#discussion_r3771229903

cc @conda-forge/r for approval

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [N/A] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [N/A] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
