### PR TITLE
Add clhep

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -296,6 +296,8 @@ ccr:
   - 1.3
 cfitsio:
   - 4.6.4
+clhep:
+  - 2.4.7.2
 cmocka:
   - 2.0.1
 coin_or_cbc:


### PR DESCRIPTION
clhep is linked by geant4, gaudi, remage, bdsim-g4, bxdecay0, geant4-vmc, lcg-relax, rave and vgm. Its run_exports already pin consumers tightly (pin_subpackage with upper_bound='x.x.x.x'), but nothing coordinates the rebuild across those feedstocks when a new clhep appears.

That coordination matters more than usual here because Geant4 writes find_dependency(CLHEP <version> EXACT) into its exported Geant4Config.cmake, so anything building against Geant4 needs the very same clhep, and a staggered rollout leaves consumers unsolvable against each other.

2.4.7.2 is the current version and what everything is already built against, so this pins the status quo and turns future bumps into a migration.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
