### PR TITLE
add paused py3.15 migration; close py3.14 migration; drop py3.10

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -974,17 +974,16 @@ pythia8:
 python:
   # win-arm64 on conda-forge supports only 3.14+
   # part of a zip_keys: python, is_python_min
-  - 3.10.* *_cpython   # [not ((win and arm64) or riscv64)]
   - 3.11.* *_cpython   # [not ((win and arm64) or riscv64)]
   - 3.12.* *_cpython   # [not ((win and arm64) or riscv64)]
   - 3.13.* *_cp313     # [not ((win and arm64) or riscv64)]
-  - 3.14.* *_cp314     # [(win and arm64) or riscv64]
+  - 3.14.* *_cp314
 python_impl:
   - cpython
 python_min:
   # minimum supported python version per CFEP-25
   # bump to next minor version when we drop python versions
-  - '3.10'             # [not ((win and arm64) or riscv64)]
+  - '3.11'             # [not ((win and arm64) or riscv64)]
   - '3.14'             # [(win and arm64) or riscv64]
 is_freethreading:
   - false

--- a/recipe/migrations/python314t.yaml
+++ b/recipe/migrations/python314t.yaml
@@ -56,3 +56,7 @@ is_python_min:
 - false
 is_abi3:
 - false
+# due to the order of migrations and their additional_zip_keys,
+# we need this here as long as 3.15 is not yet GA
+channel_sources:
+- conda-forge

--- a/recipe/migrations/python315.yaml
+++ b/recipe/migrations/python315.yaml
@@ -1,9 +1,9 @@
-# this is intentionally sorted before the 3.13t migrator, because that determines
+# this is intentionally sorted before the 3.14t migrator, because that determines
 # the order of application of the migrators; otherwise we'd have to add values for
 # is_freethreading and is_abi3 keys here, since that migration extends the zip;
-migrator_ts: 1724712607
+migrator_ts: 1755739490
 __migrator:
-    commit_message: Rebuild for python 3.14
+    commit_message: Rebuild for python 3.15
     migration_number: 1
     operation: key_add
     primary_key: python
@@ -15,7 +15,9 @@ __migrator:
             - 3.12.* *_cpython
             - 3.13.* *_cp313
             - 3.13.* *_cp313t
-            - 3.14.* *_cp314  # new entry
+            - 3.14.* *_cp314
+            - 3.14.* *_cp314t
+            - 3.15.* *_cp315  # new entry
     paused: false
     longterm: true
     pr_limit: 5
@@ -27,15 +29,17 @@ __migrator:
         - pypy-meta
         - cross-python
         - python_abi
-        # Manually migrated (e.g. were blocked on missing dev dependencies)
-        - pyarrow
     exclude_pinned_pkgs: false
     ignored_deps_per_node:
         matplotlib:
             - pyqt
+    additional_zip_keys:
+        - channel_sources
 
 python:
-- 3.14.* *_cp314
+- 3.15.* *_cp315
 # additional entries to add for zip_keys
 is_python_min:
 - false
+channel_sources:
+- conda-forge/label/python_rc,conda-forge

--- a/recipe/migrations/python315.yaml
+++ b/recipe/migrations/python315.yaml
@@ -18,7 +18,8 @@ __migrator:
             - 3.14.* *_cp314
             - 3.14.* *_cp314t
             - 3.15.* *_cp315  # new entry
-    paused: false
+    # until https://github.com/conda-forge/conda-forge.github.io/pull/2925 at least
+    paused: true
     longterm: true
     pr_limit: 5
     max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times


### PR DESCRIPTION
https://github.com/conda-forge/python-feedstock/pull/900 has been merged, so we should be ready to migrate here.

Xref #7598

I'm not proposing to close the 3.14t migration, not all feedstocks are ready for this. We should probably do as we did for 3.13t vs. 3.14t, i.e. remigrate for 3.15t (c.f. #7682), and then eventually drop the 3.14t migrator (c.f. #8262)

CC @conda-forge/core @conda-forge/python