### PR TITLE
Add migration file for VTK version 9.7.0

### DIFF
--- a/recipe/migrations/vtk970.yaml
+++ b/recipe/migrations/vtk970.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.7.0"
+  migration_number: 1
+migrator_ts: 1787616485
+vtk_base:
+- 9.7.0
+vtk:
+- 9.7.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I was chasing down why [open3d](https://github.com/conda-forge/open3d-feedstock/pull/68) was importing a gpl dependency. It turns out it was because vtk-base dependended on libnetcdf. libnetcdf had an upstream bug which was fixed and propagated to the netcdf-feedstock in v4.10 and pulled in vtk-base 9.7.0. @Tobias-Fischer suggested that I apply the fix globally instead of directly to open3d directly.  The underlying netcdf-feedstock bug pulled in `attr` on linux as a temporary patch as a workaround for the bug. 

I'm not familiar with this process, but I tried reading on it and it looks really awesome as a tool.