### PR TITLE
add cargo-auditable, cargo-bundle-licenses to linux-riscv64

### DIFF
--- a/recipe/migration_support/linux_riscv64.txt
+++ b/recipe/migration_support/linux_riscv64.txt
@@ -1,4 +1,6 @@
 anaconda-client
+cargo-auditable
+cargo-bundle-licenses
 clang
 clangxx
 cmake


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
cargo-auditable and cargo-bundle-licenses are used in a lot of rust recipes in the `build` section. we need those for linux-riscv64 already if we want to build natively