### PR TITLE
Revert "Add ffmpeg to linux-riscv64 port"

### DIFF
--- a/recipe/migration_support/linux_riscv64.txt
+++ b/recipe/migration_support/linux_riscv64.txt
@@ -8,7 +8,6 @@ conda-build
 conda-forge-ci-setup
 conda-libmamba-solver
 constructor
-ffmpeg
 git
 jinja2
 libjpeg-turbo


### PR DESCRIPTION
This reverts commit c009ed0906a5d8b70f37cd55bb5e71a4dad64d7c.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This adds too many packages. Need to wait until native runners are up.

cc @luhenry 