### PR TITLE
set python version for riscv

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -974,26 +974,26 @@ pythia8:
 python:
   # win-arm64 on conda-forge supports only 3.14+
   # part of a zip_keys: python, is_python_min
-  - 3.10.* *_cpython   # [not (win and arm64)]
-  - 3.11.* *_cpython   # [not (win and arm64)]
-  - 3.12.* *_cpython   # [not (win and arm64)]
-  - 3.13.* *_cp313     # [not (win and arm64)]
-  - 3.14.* *_cp314     # [win and arm64]
+  - 3.10.* *_cpython   # [not ((win and arm64) or riscv64)]
+  - 3.11.* *_cpython   # [not ((win and arm64) or riscv64)]
+  - 3.12.* *_cpython   # [not ((win and arm64) or riscv64)]
+  - 3.13.* *_cp313     # [not ((win and arm64) or riscv64)]
+  - 3.14.* *_cp314     # [(win and arm64) or riscv64]
 python_impl:
   - cpython
 python_min:
   # minimum supported python version per CFEP-25
   # bump to next minor version when we drop python versions
-  - '3.10'             # [not (win and arm64)]
-  - '3.14'             # [win and arm64]
+  - '3.10'             # [not ((win and arm64) or riscv64)]
+  - '3.14'             # [(win and arm64) or riscv64]
 is_freethreading:
   - false
 is_python_min:
   # part of a zip_keys: python, is_python_min
   - true
-  - false              # [not (win and arm64)]
-  - false              # [not (win and arm64)]
-  - false              # [not (win and arm64)]
+  - false              # [not ((win and arm64) or riscv64)]
+  - false              # [not ((win and arm64) or riscv64)]
+  - false              # [not ((win and arm64) or riscv64)]
 is_abi3:
   - true
 pytorch:


### PR DESCRIPTION
Now that https://github.com/conda-forge/python-feedstock/pull/896 is merged, some people will start working ~immediately on all the feedstocks that were blocked on that. We need to set a python version for riscv.