### PR TITLE
use new `replacements:` feature for dav1d

### DIFF
--- a/recipe/migrations/dav1d154.yaml
+++ b/recipe/migrations/dav1d154.yaml
@@ -2,7 +2,10 @@ __migrator:
   build_number: 1
   commit_message: Rebuild for dav1d 1.5.4 and rename dav1d to dav1d-devel
   kind: version
-  migration_number: 1
+  migration_number: 2
+  replacements:
+    - old_pkg: dav1d
+      new_pkg: dav1d-devel
 dav1d:
 - '1.5.4'
 dav1d_devel:


### PR DESCRIPTION
Another follow-up to #8764, because in #8903 I missed (and thus broke) the relation of the filename with the minimigrator in the bot repo. However, this provides an opportunity to try out brand-new [infrastructure](https://github.com/conda-forge/conda-forge-bot/pull/6593) that creates these minimigrators on the fly, without having to patch the bot repo each time.