### PR TITLE
remove settings for armv7l

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -188,12 +188,6 @@ zip_keys:
     - root_base
     - root_cxx_standard
 
-# armv7l specifics because conda-build sets many things to centos 6
-# this can probably be removed when conda-build gets updated defaults
-# for aarch64
-cdt_arch: armv7l                          # [armv7l]
-BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
-
 pin_run_as_build:
   libblst:
     max_pin: x.x


### PR DESCRIPTION
I haven't seen this target in use anywhere over the last 5+ years. The comment (from 7167b3943935a95007eaa3121f8ef2444c8465d4, 7 years ago) already mentions "this can probably be removed when conda-build gets updated defaults for aarch64". Also worth noting that none of the other changes from that commit have remained until today.