### PR TITLE
Start py315 migration

### DIFF
--- a/recipe/migrations/python314t.yaml
+++ b/recipe/migrations/python314t.yaml
@@ -12,8 +12,9 @@ __migrator:
             - 3.12.* *_cpython
             - 3.13.* *_cp313
             - 3.13.* *_cp313t
-            - 3.14.* *_cp314    # new entry
+            - 3.14.* *_cp314
             - 3.14.* *_cp314t   # new entry
+            - 3.15.* *_cp315
     longterm: true
     pr_limit: 20
     max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times

--- a/recipe/migrations/python315.yaml
+++ b/recipe/migrations/python315.yaml
@@ -18,8 +18,7 @@ __migrator:
             - 3.14.* *_cp314
             - 3.14.* *_cp314t
             - 3.15.* *_cp315  # new entry
-    # until https://github.com/conda-forge/conda-forge.github.io/pull/2925 at least
-    paused: true
+    paused: false
     longterm: true
     pr_limit: 5
     max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times

--- a/recipe/migrations/python315.yaml
+++ b/recipe/migrations/python315.yaml
@@ -42,4 +42,4 @@ python:
 is_python_min:
 - false
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge,conda-forge/label/python_rc


### PR DESCRIPTION
Actually start the python 3.15 migration (deferred from #8891), pending
- https://github.com/conda-forge/conda-forge.github.io/pull/2925
- https://github.com/conda-forge/cross-python-feedstock/pull/108
- and whatever else we may want to do beforehand

Preview of (currently paused) migrator can be seen [here](https://conda-forge.org/status/migration/?name=python315)