### PR TITLE
Add opensees to arch_rebuild

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -605,8 +605,8 @@ openmm
 openmotif
 openmpi
 openorbitaloptimizer
-opensees
 openscenegraph
+opensees
 openslide
 openslide-python
 openssh

--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -605,6 +605,7 @@ openmm
 openmotif
 openmpi
 openorbitaloptimizer
+opensees
 openscenegraph
 openslide
 openslide-python


### PR DESCRIPTION
Checklist

* [x] Used a personal fork of the feedstock to propose changes

This PR adds `opensees` to
`recipe/migration_support/arch_rebuild.txt` so that it can be included
in the Linux AArch64/PPC64LE architecture migration.

I have built and tested OpenSees 3.8.0 natively on Linux AArch64 with:

- Python 3.12
- Python 3.13
- Python 3.14

The following local checks passed:

- `conda build`
- `conda build --test`
- installation into clean environments
- importing the `opensees` Python module
- OpenSeesPy numerical smoke test
- OpenSees Tcl numerical smoke test
- AArch64 ELF verification
- shared-library dependency checks

Only Linux AArch64 has been tested locally.