### PR TITLE
add simsimd and stringzilla for aarch64 migration

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -1223,6 +1223,7 @@ shap
 shellcheck
 shrinkwrap
 silicon
+simsimd
 singularity
 sirius-ms
 sixs
@@ -1256,6 +1257,7 @@ stardist
 starship
 statsforecast
 statsmodels
+stringzilla
 su-exec
 subfinder
 suitesparse


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This PR adds `simsimd` and `stringzilla` to `arch_rebuild.txt` to enable linux-aarch64 builds.