### PR TITLE
add selenium-manager for aarch64 migration

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -1217,6 +1217,7 @@ sdf
 sdl
 sdl_image
 sdsl-lite
+selenium-manager
 seqan-library
 sfml
 shap


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This PR adds `selenium-manager` to `arch_rebuild.txt` to enable linux-aarch64 builds.