### PR TITLE
add datatable for aarch64 migration

### DIFF
--- a/recipe/migration_support/arch_rebuild.txt
+++ b/recipe/migration_support/arch_rebuild.txt
@@ -187,6 +187,7 @@ dataclasses
 datafusion
 datamash
 dataprep
+datatable
 datavzrd
 dav1d
 dbus


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This PR adds `datatable` to `arch_rebuild.txt` to enable linux-aarch64 builds.