### PR TITLE
ignore pandas for hypothesis (test-only dep)

### DIFF
--- a/recipe/migrations/python315.yaml
+++ b/recipe/migrations/python315.yaml
@@ -33,6 +33,8 @@ __migrator:
     ignored_deps_per_node:
         matplotlib:
             - pyqt
+        hypothesis:
+            - pandas
     additional_zip_keys:
         - channel_sources
 


### PR DESCRIPTION
The bot sees a cycle between hypothesis and pandas; fixed in https://github.com/conda-forge/hypothesis-feedstock/pull/1243